### PR TITLE
✨(entitlements) surface can_upload reason on drive resolver

### DIFF
--- a/src/backend/core/entitlements/resolvers/drive_access_entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/drive_access_entitlement_resolver.py
@@ -1,4 +1,9 @@
-class DriveAccessEntitlementResolver:
+from core.entitlements.resolvers.access_entitlement_resolver import (
+    AccessEntitlementResolver,
+)
+
+
+class DriveAccessEntitlementResolver(AccessEntitlementResolver):
     """
     Drive access entitlement resolver.
     """
@@ -9,7 +14,19 @@ class DriveAccessEntitlementResolver:
         We always return true for the drive access entitlement even without a subscription.
         We want users to be able to access the drive service even without a subscription.
         But in this case, we will not return any entitlement, so the user will not be able to upload files.
+
+        The strange behavior for can_upload is because, when there is no organization or no active subscription,
+        the can_upload entitlement is not resolved, but we want to give information about the reason why
+        the user cannot upload files. In some case on Drive we need to display a message to the user to explain
+        that he cannot upload files because he is not subscribed to the service, not especially for the case
+        that his storage is full.
         """
-        return {
+        parent_output = super().resolve(context)
+        output = {
             "can_access": True,
         }
+        # Means there is no organization or no active subscription.
+        if not parent_output["can_access"]:
+            output["can_upload"] = False
+            output["can_upload_reason"] = parent_output["can_access_reason"]
+        return output

--- a/src/backend/core/tests/api/test_entitlements_drive.py
+++ b/src/backend/core/tests/api/test_entitlements_drive.py
@@ -1,4 +1,5 @@
 # pylint: disable=invalid-name
+# pylint: disable=too-many-lines
 """
 Test entitlements drive API endpoints in the deploycenter core app.
 """
@@ -9,6 +10,7 @@ from responses import matchers
 from rest_framework.test import APIClient
 
 from core import factories, models
+from core.entitlements.resolvers import AccessEntitlementResolver
 from core.tests.utils import assert_equals_partial
 
 pytestmark = pytest.mark.django_db
@@ -148,6 +150,8 @@ def test_api_entitlements_can_access_without_subscription(
         "potentialOperators": [],
         "entitlements": {
             "can_access": True,
+            "can_upload": False,
+            "can_upload_reason": AccessEntitlementResolver.Reason.NOT_ACTIVATED,
         },
     }
 
@@ -181,6 +185,8 @@ def test_api_entitlements_can_access_without_subscription(
         "potentialOperators": [],
         "entitlements": {
             "can_access": True,
+            "can_upload": False,
+            "can_upload_reason": AccessEntitlementResolver.Reason.NOT_ACTIVATED,
         },
     }
 
@@ -980,3 +986,68 @@ def test_api_entitlements_list_unlimited_storage(
             },
         },
     )
+
+
+@pytest.mark.django_db()
+@responses.activate
+@pytest.mark.parametrize(
+    "has_organization,has_subscription,is_active,expected_reason",
+    [
+        # No organization matches the requested siret.
+        (False, False, None, AccessEntitlementResolver.Reason.NO_ORGANIZATION),
+        # Organization exists but no subscription was ever created for the service.
+        (True, False, None, AccessEntitlementResolver.Reason.NOT_ACTIVATED),
+        # Organization exists with an inactive subscription.
+        (True, True, False, AccessEntitlementResolver.Reason.NOT_ACTIVATED),
+    ],
+)
+def test_api_entitlements_drive_can_upload_reason(
+    has_organization, has_subscription, is_active, expected_reason
+):
+    """
+    The drive resolver should expose can_upload=False with can_upload_reason when
+    the parent access check fails (no organization or no active subscription) so the
+    frontend can explain why upload is unavailable instead of falling back to the
+    generic "storage full" message.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    siret = "12345678900001"
+    service = factories.ServiceFactory(
+        type="drive",
+        config={"entitlements_api_key": "test_token"},
+    )
+
+    if has_organization:
+        operator = factories.OperatorFactory()
+        organization = factories.OrganizationFactory(siret=siret)
+        factories.OperatorOrganizationRoleFactory(
+            operator=operator, organization=organization
+        )
+        if has_subscription:
+            factories.ServiceSubscriptionFactory(
+                organization=organization,
+                service=service,
+                operator=operator,
+                is_active=is_active,
+            )
+
+    response = client.get(
+        "/api/v1.0/entitlements/",
+        query_params={
+            "service_id": service.id,
+            "account_type": "user",
+            "account_id": "xyz",
+            "siret": siret,
+        },
+        headers={"X-Service-Auth": "Bearer test_token"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["entitlements"] == {
+        "can_access": True,
+        "can_upload": False,
+        "can_upload_reason": expected_reason,
+    }


### PR DESCRIPTION
## Summary

On Drive, we need to show a disclaimer on connexion if user has no organization or if the service is not activated. As `can_access` is always true, we need to provide more information about `can_upload` as the disclaimer trigger is based on this flag. We need the reason to be able to distinguish the case were `can_upload` is False due to full storage, in which case we do not want to show the same message.

- Make `DriveAccessEntitlementResolver` inherit from `AccessEntitlementResolver` so it can reuse the parent's access check.
- When the parent resolver denies access (no organization or no active subscription), expose `can_upload=False` with `can_upload_reason` copied from `can_access_reason`, so the frontend can explain why upload is unavailable instead of defaulting to a generic "storage full" message.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drive access entitlements now return upload permission status with detailed denial reasons when applicable.
  * API responses include explicit upload authorization indicators alongside access permissions.

* **Tests**
  * Enhanced test coverage for drive upload validation across various access scenarios.
  * Added parametrized tests for upload failure cases with specific denial reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->