### PR TITLE
✨(all) hidden service flag + transfers access resolver

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -349,6 +349,7 @@ class ServiceSerializer(serializers.ModelSerializer):
             "maturity",
             "launch_date",
             "is_active",
+            "hidden",
             "created_at",
             "logo",
             "config",

--- a/src/backend/core/entitlements/resolvers/__init__.py
+++ b/src/backend/core/entitlements/resolvers/__init__.py
@@ -23,6 +23,9 @@ from core.entitlements.resolvers.messages_admin_entitlement_resolver import (
 from core.entitlements.resolvers.messages_storage_entitlement_resolver import (
     MessagesStorageEntitlementResolver,
 )
+from core.entitlements.resolvers.transfers_access_entitlement_resolver import (
+    TransfersAccessEntitlementResolver,
+)
 
 TYPE_TO_RESOLVER = {
     models.Entitlement.EntitlementType.DRIVE_STORAGE: DriveStorageEntitlementResolver,
@@ -33,6 +36,7 @@ TYPE_TO_RESOLVER = {
 TYPE_TO_ACCESS_RESOLVER = {
     "drive": DriveAccessEntitlementResolver,
     "meet": MeetAccessEntitlementResolver,
+    "transfers": TransfersAccessEntitlementResolver,
 }
 
 

--- a/src/backend/core/entitlements/resolvers/transfers_access_entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/transfers_access_entitlement_resolver.py
@@ -1,0 +1,33 @@
+from core import models
+from core.entitlements.resolvers.access_entitlement_resolver import (
+    AccessEntitlementResolver,
+)
+
+
+class TransfersAccessEntitlementResolver(AccessEntitlementResolver):
+    """
+    Transfers access entitlement resolver.
+
+    Transfers is a hidden service piggy-backing on Drive: an organization can
+    access it only if it already has an active subscription to a Drive service.
+    We delegate to the parent ``_resolve_with_subscription`` after swapping the
+    context's ``service_subscription`` for the organization's drive subscription,
+    so the NO_ORGANIZATION / NOT_ACTIVATED branches stay in one place.
+    """
+
+    def resolve(self, context):
+        drive_subscription = None
+        if context.get("organization"):
+            drive_subscription = models.ServiceSubscription.objects.filter(
+                organization=context["organization"],
+                service__type="drive",
+                is_active=True,
+            ).first()
+
+        can_access, can_access_reason = self._resolve_with_subscription(
+            {**context, "service_subscription": drive_subscription}
+        )
+        res = {"can_access": can_access}
+        if can_access_reason:
+            res["can_access_reason"] = can_access_reason
+        return res

--- a/src/backend/core/migrations/0020_service_hidden.py
+++ b/src/backend/core/migrations/0020_service_hidden.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0019_external_management_api_key"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="service",
+            name="hidden",
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether this service should be hidden from frontend listings",
+                verbose_name="hidden",
+            ),
+        ),
+    ]

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -921,6 +921,13 @@ class Service(BaseModel):
             return f"{settings.API_PUBLIC_URL}servicelogo/{self.id}/"
         return None
 
+    @property
+    def hidden(self):
+        """
+        Whether the service should be hidden from frontend listings.
+        """
+        return bool((self.config or {}).get("hidden", False))
+
     def can_activate(self, organization: Organization, operator: "Operator" = None):
         """
         Check if the service can be activated for the given organization.

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -877,6 +877,12 @@ class Service(BaseModel):
         help_text=_("Whether this service is currently available for subscription"),
     )
 
+    hidden = models.BooleanField(
+        _("hidden"),
+        default=False,
+        help_text=_("Whether this service should be hidden from frontend listings"),
+    )
+
     logo_svg = models.BinaryField(
         _("logo SVG"),
         blank=True,
@@ -920,13 +926,6 @@ class Service(BaseModel):
         if self.logo_svg:
             return f"{settings.API_PUBLIC_URL}servicelogo/{self.id}/"
         return None
-
-    @property
-    def hidden(self):
-        """
-        Whether the service should be hidden from frontend listings.
-        """
-        return bool((self.config or {}).get("hidden", False))
 
     def can_activate(self, organization: Organization, operator: "Operator" = None):
         """

--- a/src/backend/core/tasks/datagouv.py
+++ b/src/backend/core/tasks/datagouv.py
@@ -72,7 +72,7 @@ def upload_deployment_metrics_dataset():
         .exclude(organization__siret__isnull=True)
         .exclude(organization__siret="")
         .filter(service__is_active=True)
-        .exclude(service__config__hidden=True)
+        .exclude(service__hidden=True)
     )
 
     data = {
@@ -138,7 +138,7 @@ def upload_deployment_services_dataset():
     dataset_id = "68b0a2a1117b75b1b09edc6b"
     resource_id = "610560cf-5893-4a53-b4d3-03e17d877e1c"
 
-    services = Service.objects.filter(is_active=True).exclude(config__hidden=True)
+    services = Service.objects.filter(is_active=True).exclude(hidden=True)
 
     data = [
         {
@@ -183,8 +183,10 @@ def upload_deployment_operators_dataset():
     resource_id = "902bb360-0b60-46d2-8169-4207a01caed1"
 
     # First, get all operators with non-empty status
-    operators = Operator.objects.filter(is_active=True, status__isnull=False).exclude(status="").order_by(
-        "name"
+    operators = (
+        Operator.objects.filter(is_active=True, status__isnull=False)
+        .exclude(status="")
+        .order_by("name")
     )
 
     # Then, for each operator, get their services with display_priority >= -100
@@ -195,7 +197,7 @@ def upload_deployment_operators_dataset():
             OperatorServiceConfig.objects.filter(
                 operator=operator, display_priority__gte=-100
             )
-            .exclude(service__config__hidden=True)
+            .exclude(service__hidden=True)
             .values_list("service_id", flat=True)
             .order_by("-display_priority")
         )
@@ -321,7 +323,7 @@ def upload_deployment_subscriptions_dataset():
         )
         .filter(organization__type__in=["commune", "epci", "departement", "region"])
         .filter(service__is_active=True)
-        .exclude(service__config__hidden=True)
+        .exclude(service__hidden=True)
         .filter(operator__is_active=True)
         .filter(is_active=True)
     )

--- a/src/backend/core/tasks/datagouv.py
+++ b/src/backend/core/tasks/datagouv.py
@@ -72,6 +72,7 @@ def upload_deployment_metrics_dataset():
         .exclude(organization__siret__isnull=True)
         .exclude(organization__siret="")
         .filter(service__is_active=True)
+        .exclude(service__config__hidden=True)
     )
 
     data = {
@@ -137,7 +138,7 @@ def upload_deployment_services_dataset():
     dataset_id = "68b0a2a1117b75b1b09edc6b"
     resource_id = "610560cf-5893-4a53-b4d3-03e17d877e1c"
 
-    services = Service.objects.filter(is_active=True)
+    services = Service.objects.filter(is_active=True).exclude(config__hidden=True)
 
     data = [
         {
@@ -194,6 +195,7 @@ def upload_deployment_operators_dataset():
             OperatorServiceConfig.objects.filter(
                 operator=operator, display_priority__gte=-100
             )
+            .exclude(service__config__hidden=True)
             .values_list("service_id", flat=True)
             .order_by("-display_priority")
         )
@@ -319,6 +321,7 @@ def upload_deployment_subscriptions_dataset():
         )
         .filter(organization__type__in=["commune", "epci", "departement", "region"])
         .filter(service__is_active=True)
+        .exclude(service__config__hidden=True)
         .filter(operator__is_active=True)
         .filter(is_active=True)
     )

--- a/src/backend/core/tasks/datagouv.py
+++ b/src/backend/core/tasks/datagouv.py
@@ -155,6 +155,13 @@ def upload_deployment_services_dataset():
         for service in services
     ]
 
+    if not data:
+        logger.info("No active visible services to export; skipping data.gouv upload")
+        return {
+            "status": "success",
+            "message": "No data to upload",
+        }
+
     buffer = io.StringIO()
     writer = csv.DictWriter(buffer, fieldnames=data[0].keys(), delimiter=";")
     writer.writeheader()

--- a/src/backend/core/tests/api/test_entitlements_transfers.py
+++ b/src/backend/core/tests/api/test_entitlements_transfers.py
@@ -1,0 +1,237 @@
+# pylint: disable=invalid-name
+"""
+Test entitlements transfers API endpoints in the deploycenter core app.
+
+The transfers service does not have its own subscription model: an organization
+can access it iff it has an active subscription to a Drive service.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from core import factories
+from core.entitlements.resolvers.transfers_access_entitlement_resolver import (
+    TransfersAccessEntitlementResolver,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_transfers_service():
+    return factories.ServiceFactory(
+        type="transfers",
+        config={
+            "entitlements_api_key": "test_token",
+        },
+    )
+
+
+def _call_entitlements(client, service, siret):
+    return client.get(
+        "/api/v1.0/entitlements/",
+        query_params={
+            "service_id": service.id,
+            "account_type": "user",
+            "account_id": "xyz",
+            "siret": siret,
+        },
+        headers={"X-Service-Auth": "Bearer test_token"},
+    )
+
+
+def test_api_entitlements_transfers_can_access_with_active_drive_subscription():
+    """
+    Transfers grants access when the organization has an active drive subscription.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    operator = factories.OperatorFactory()
+    organization = factories.OrganizationFactory(siret="12345678900001")
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=organization
+    )
+
+    drive_service = factories.ServiceFactory(type="drive")
+    factories.ServiceSubscriptionFactory(
+        organization=organization, service=drive_service, operator=operator
+    )
+
+    transfers_service = _make_transfers_service()
+
+    response = _call_entitlements(client, transfers_service, organization.siret)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "organization": {
+            "id": str(organization.id),
+            "type": organization.type,
+            "name": organization.name,
+            "oidc_valid": None,
+        },
+        "operator": None,
+        "potentialOperators": [],
+        "entitlements": {
+            "can_access": True,
+        },
+    }
+
+
+def test_api_entitlements_transfers_can_access_without_drive_subscription():
+    """
+    Transfers denies access when the organization has no drive subscription at all.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    operator = factories.OperatorFactory()
+    organization = factories.OrganizationFactory(siret="12345678900001")
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=organization
+    )
+
+    transfers_service = _make_transfers_service()
+
+    response = _call_entitlements(client, transfers_service, organization.siret)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "organization": {
+            "id": str(organization.id),
+            "type": organization.type,
+            "name": organization.name,
+            "oidc_valid": None,
+        },
+        "operator": None,
+        "potentialOperators": [],
+        "entitlements": {
+            "can_access": False,
+            "can_access_reason": TransfersAccessEntitlementResolver.Reason.NOT_ACTIVATED,
+        },
+    }
+
+
+def test_api_entitlements_transfers_can_access_with_inactive_drive_subscription():
+    """
+    Transfers denies access when the drive subscription exists but is inactive.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    operator = factories.OperatorFactory()
+    organization = factories.OrganizationFactory(siret="12345678900001")
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=organization
+    )
+
+    drive_service = factories.ServiceFactory(type="drive")
+    factories.ServiceSubscriptionFactory(
+        organization=organization,
+        service=drive_service,
+        operator=operator,
+        is_active=False,
+    )
+
+    transfers_service = _make_transfers_service()
+
+    response = _call_entitlements(client, transfers_service, organization.siret)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["entitlements"] == {
+        "can_access": False,
+        "can_access_reason": TransfersAccessEntitlementResolver.Reason.NOT_ACTIVATED,
+    }
+
+
+def test_api_entitlements_transfers_can_access_no_organization():
+    """
+    Transfers denies access with NO_ORGANIZATION when the siret matches no org.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    transfers_service = _make_transfers_service()
+
+    response = _call_entitlements(client, transfers_service, "99999999999999")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "organization": None,
+        "operator": None,
+        "entitlements": {
+            "can_access": False,
+            "can_access_reason": TransfersAccessEntitlementResolver.Reason.NO_ORGANIZATION,
+        },
+    }
+
+
+def test_api_entitlements_transfers_ignores_transfers_subscription():
+    """
+    A transfers-only subscription must not grant access — the gating depends on
+    drive, not on transfers' own subscription.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    operator = factories.OperatorFactory()
+    organization = factories.OrganizationFactory(siret="12345678900001")
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=organization
+    )
+
+    transfers_service = _make_transfers_service()
+    factories.ServiceSubscriptionFactory(
+        organization=organization, service=transfers_service, operator=operator
+    )
+
+    response = _call_entitlements(client, transfers_service, organization.siret)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["entitlements"]["can_access"] is False
+    assert (
+        data["entitlements"]["can_access_reason"]
+        == TransfersAccessEntitlementResolver.Reason.NOT_ACTIVATED
+    )
+
+
+def test_api_entitlements_transfers_ignores_other_org_drive_subscription():
+    """
+    A drive subscription belonging to a different organization must not leak access.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    operator = factories.OperatorFactory()
+
+    organization = factories.OrganizationFactory(siret="12345678900001")
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=organization
+    )
+
+    other_organization = factories.OrganizationFactory(siret="98765432100001")
+    drive_service = factories.ServiceFactory(type="drive")
+    factories.ServiceSubscriptionFactory(
+        organization=other_organization, service=drive_service, operator=operator
+    )
+
+    transfers_service = _make_transfers_service()
+
+    response = _call_entitlements(client, transfers_service, organization.siret)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["entitlements"] == {
+        "can_access": False,
+        "can_access_reason": TransfersAccessEntitlementResolver.Reason.NOT_ACTIVATED,
+    }

--- a/src/backend/core/tests/api/test_services.py
+++ b/src/backend/core/tests/api/test_services.py
@@ -7,9 +7,20 @@ Test users API endpoints in the deploycenter core app.
 import pytest
 from rest_framework.test import APIClient
 
-from core import factories
+from core import factories, models
 
 pytestmark = pytest.mark.django_db
+
+
+def test_service_hidden_property():
+    """
+    Service.hidden derives from config["hidden"] and defaults to False when
+    the key is missing or the config is null.
+    """
+    assert models.Service(config={"hidden": True}).hidden is True
+    assert models.Service(config={"hidden": False}).hidden is False
+    assert models.Service(config={}).hidden is False
+    assert models.Service(config=None).hidden is False
 
 
 def test_api_organizations_services_list_anonymous():
@@ -193,6 +204,39 @@ def test_api_organizations_services_list_authenticated():
         f"/api/v1.0/operators/{operator2.id}/organizations/{organization_ok1.id}/services/"
     )
     assert response.status_code == 403
+
+
+def test_api_organizations_services_list_exposes_hidden():
+    """
+    Services expose a `hidden` boolean derived from config.hidden.
+    The API still returns hidden services — frontend handles tile filtering.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    operator = factories.OperatorFactory()
+    factories.UserOperatorRoleFactory(user=user, operator=operator)
+
+    organization = factories.OrganizationFactory()
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=organization
+    )
+
+    visible_service = factories.ServiceFactory(config={})
+    hidden_service = factories.ServiceFactory(config={"hidden": True})
+
+    factories.OperatorServiceConfigFactory(operator=operator, service=visible_service)
+    factories.OperatorServiceConfigFactory(operator=operator, service=hidden_service)
+
+    response = client.get(
+        f"/api/v1.0/operators/{operator.id}/organizations/{organization.id}/services/"
+    )
+    assert response.status_code == 200
+
+    results_by_id = {result["id"]: result for result in response.json()["results"]}
+    assert results_by_id[visible_service.id]["hidden"] is False
+    assert results_by_id[hidden_service.id]["hidden"] is True
 
 
 def test_api_organization_service_enable_delete():

--- a/src/backend/core/tests/api/test_services.py
+++ b/src/backend/core/tests/api/test_services.py
@@ -7,20 +7,9 @@ Test users API endpoints in the deploycenter core app.
 import pytest
 from rest_framework.test import APIClient
 
-from core import factories, models
+from core import factories
 
 pytestmark = pytest.mark.django_db
-
-
-def test_service_hidden_property():
-    """
-    Service.hidden derives from config["hidden"] and defaults to False when
-    the key is missing or the config is null.
-    """
-    assert models.Service(config={"hidden": True}).hidden is True
-    assert models.Service(config={"hidden": False}).hidden is False
-    assert models.Service(config={}).hidden is False
-    assert models.Service(config=None).hidden is False
 
 
 def test_api_organizations_services_list_anonymous():
@@ -208,7 +197,7 @@ def test_api_organizations_services_list_authenticated():
 
 def test_api_organizations_services_list_exposes_hidden():
     """
-    Services expose a `hidden` boolean derived from config.hidden.
+    Services expose a `hidden` boolean field.
     The API still returns hidden services — frontend handles tile filtering.
     """
     user = factories.UserFactory()
@@ -223,8 +212,8 @@ def test_api_organizations_services_list_exposes_hidden():
         operator=operator, organization=organization
     )
 
-    visible_service = factories.ServiceFactory(config={})
-    hidden_service = factories.ServiceFactory(config={"hidden": True})
+    visible_service = factories.ServiceFactory()
+    hidden_service = factories.ServiceFactory(hidden=True)
 
     factories.OperatorServiceConfigFactory(operator=operator, service=visible_service)
     factories.OperatorServiceConfigFactory(operator=operator, service=hidden_service)

--- a/src/frontend/src/features/api/Repository.ts
+++ b/src/frontend/src/features/api/Repository.ts
@@ -127,6 +127,7 @@ export type Service = {
   type: string;
   subscription: ServiceSubscription;
   logo: string | null;
+  hidden?: boolean;
   operator_config?: {
     display_priority?: number;
     externally_managed?: boolean;

--- a/src/frontend/src/pages/operators/[operator_id]/organizations/[id].tsx
+++ b/src/frontend/src/pages/operators/[operator_id]/organizations/[id].tsx
@@ -62,15 +62,17 @@ export default function Organization() {
     if (!services?.results) {
       return [];
     }
-    return [...services.results].sort((a, b) => {
-      const aIsProConnect = a.type === SERVICE_TYPE_PROCONNECT;
-      const bIsProConnect = b.type === SERVICE_TYPE_PROCONNECT;
-      if (aIsProConnect && !bIsProConnect) return -1;
-      if (!aIsProConnect && bIsProConnect) return 1;
-      const priorityA = a.operator_config?.display_priority ?? -Infinity;
-      const priorityB = b.operator_config?.display_priority ?? -Infinity;
-      return priorityB - priorityA; // descending order, nulls at the end
-    });
+    return [...services.results]
+      .filter((service) => !service.hidden)
+      .sort((a, b) => {
+        const aIsProConnect = a.type === SERVICE_TYPE_PROCONNECT;
+        const bIsProConnect = b.type === SERVICE_TYPE_PROCONNECT;
+        if (aIsProConnect && !bIsProConnect) return -1;
+        if (!aIsProConnect && bIsProConnect) return 1;
+        const priorityA = a.operator_config?.display_priority ?? -Infinity;
+        const priorityB = b.operator_config?.display_priority ?? -Infinity;
+        return priorityB - priorityA; // descending order, nulls at the end
+      });
   }, [services]);
 
 


### PR DESCRIPTION
## Summary

- New `TransfersAccessEntitlementResolver` registered for `service.type="transfers"`. Access is granted iff the same organization has an active subscription to a service of `type="drive"`. Reuses the base `_resolve_with_subscription` so NO_ORGANIZATION / NOT_ACTIVATED branches stay in one place.
- New `Service.hidden` property derived from `config["hidden"]` (no DB column / migration). Exposed by `ServiceSerializer`; the org page's tile listing filters hidden services out client-side. Other consumers of the services list (messages/drive cross-lookups) keep seeing them.

Together this lets us register transfers as a real `Service` so subscriptions / entitlements / admin tooling keep working, while it stays invisible from the tile UI — its access is surfaced through Drive instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Services can be marked hidden; the API now includes a per-service hidden flag and the frontend omits hidden services from listings.
  * Transfers service type now uses a specific entitlement resolver that checks for an active Drive subscription before granting access.

* **Tests**
  * Added API tests covering transfers entitlements and the hidden service flag.

* **Chores**
  * Data export tasks now exclude hidden services; DB migration added for the hidden field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/st-deploycenter/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->