### PR TITLE
✨(cards) add admin links in some cards, to copy Messages

### DIFF
--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -864,6 +864,7 @@ class OrganizationAdmin(admin.ModelAdmin):
     search_fields = (
         "name",
         "code_insee",
+        "siret",
         "siren",
         "code_postal",
         "epci_libelle",

--- a/src/backend/core/api/viewsets/entitlements.py
+++ b/src/backend/core/api/viewsets/entitlements.py
@@ -308,6 +308,8 @@ class EntitlementView(APIView):
         entitlements_data = {**access_resolver.resolve(entitlement_context)}
         metrics_data = {}
 
+        admin_resolver = get_admin_entitlement_resolver(service)
+
         if service_subscription and service_subscription.is_active:
             operator_data = EntitlementOperatorSerializer(
                 service_subscription.operator
@@ -348,7 +350,7 @@ class EntitlementView(APIView):
             # Resolve admin entitlement.
             entitlements_data = {
                 **entitlements_data,
-                **get_admin_entitlement_resolver(service).resolve(entitlement_context),
+                **admin_resolver.resolve(entitlement_context),
             }
         elif organization:
             # For piggyback services (e.g. transfers on top of drive), there is
@@ -361,6 +363,22 @@ class EntitlementView(APIView):
                 potential_operators_data = _find_potential_operators(
                     organization, service
                 )
+
+        # Cross-organization admin resolvers (e.g. Messages) aggregate admin
+        # rights across *other* organizations, so they must run even when the
+        # queried organization has no active subscription of its own. When the
+        # queried org *is* active, the admin entitlement was already resolved
+        # inside the branch above, so we skip it here to avoid resolving twice.
+        active_subscription = bool(
+            service_subscription and service_subscription.is_active
+        )
+        if not active_subscription and getattr(
+            admin_resolver, "runs_without_active_subscription", False
+        ):
+            entitlements_data = {
+                **entitlements_data,
+                **admin_resolver.resolve(entitlement_context),
+            }
 
         organization_data = None
         if organization:

--- a/src/backend/core/api/viewsets/service.py
+++ b/src/backend/core/api/viewsets/service.py
@@ -62,13 +62,20 @@ class OrganizationServiceViewSet(viewsets.ReadOnlyModelViewSet):
     GET /api/v1.0/operators/<operator_id>/organizations/<organization_id>/services/
         Return the list of services including the subscription for the given organization
         based on the user's permissions.
+
+    Supports both user authentication and external API key authentication.
     """
 
     queryset = models.Service.objects.all()
     serializer_class = serializers.OrganizationServiceSerializer
+    authentication_classes = [
+        OperatorExternalManagementApiKeyAuthentication,
+        ServiceExternalManagementApiKeyAuthentication,
+    ] + [*api_settings.DEFAULT_AUTHENTICATION_CLASSES]
     permission_classes = [
         permissions.IsAuthenticatedWithAnyMethod,
-        permissions.OperatorAndOrganizationAccessPermission,
+        permissions.OperatorAndOrganizationAccessPermission
+        | permissions.ServiceExternalManagementPermission,
     ]
 
     def get_queryset(self):

--- a/src/backend/core/entitlements/resolvers/__init__.py
+++ b/src/backend/core/entitlements/resolvers/__init__.py
@@ -47,6 +47,8 @@ TYPE_TO_ACCESS_RESOLVER = {
 class NoopAdminEntitlementResolver:
     """No-op admin entitlement resolver for services that don't need admin entitlements."""
 
+    runs_without_active_subscription = False
+
     def resolve(self, context):
         return {}
 

--- a/src/backend/core/entitlements/resolvers/entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/entitlement_resolver.py
@@ -95,6 +95,12 @@ class EntitlementResolver:
 
     resolve_level_prefix = ""
 
+    # When True, this resolver is invoked even when the queried organization has
+    # no active subscription for the service. Used by cross-organization admin
+    # resolvers that aggregate rights across *other* organizations (e.g. Messages
+    # admin domains), which must not be gated by the queried org's own activation.
+    runs_without_active_subscription = False
+
     def __init__(self):
         self.metrics_data = {}
 

--- a/src/backend/core/entitlements/resolvers/messages_admin_entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/messages_admin_entitlement_resolver.py
@@ -26,7 +26,13 @@ class MessagesAdminEntitlementResolver(AdminEntitlementResolver):
     operator_admins_have_admin_role=True, users with a UserOperatorRole
     for that operator are granted unrestricted mail domain admin on
     the corresponding organization's subscriptions.
+
+    Because this resolver aggregates admin rights across *all* organizations
+    (not just the queried one), it must run even when the queried organization
+    has no active subscription of its own.
     """
+
+    runs_without_active_subscription = True
 
     def resolve(self, context):
         account_email = context.get("account_email") or ""

--- a/src/backend/core/tests/api/test_entitlements_messages_admin.py
+++ b/src/backend/core/tests/api/test_entitlements_messages_admin.py
@@ -925,7 +925,9 @@ def test_operator_admin_passthrough_only_with_email():
 
 
 def test_operator_admin_passthrough_inactive_subscription():
-    """Inactive subscription → admin resolver doesn't run, no can_admin_maildomains."""
+    """Inactive subscription for the queried org → no domains, but the field is
+    still present (empty), since the Messages admin resolver is cross-org and
+    always runs."""
     user = factories.UserFactory(email="admin@operator.fr")
     client = APIClient()
     client.force_login(user)
@@ -953,7 +955,7 @@ def test_operator_admin_passthrough_inactive_subscription():
         client, service, organization.siret, account_email="admin@operator.fr"
     )
     assert response.status_code == 200
-    assert "can_admin_maildomains" not in response.json()["entitlements"]
+    assert response.json()["entitlements"]["can_admin_maildomains"] == []
 
 
 def test_operator_admin_passthrough_multiple_orgs():
@@ -1034,7 +1036,8 @@ def test_operator_admin_passthrough_mixed_flags():
 
 
 def test_operator_admin_passthrough_requires_active_service_subscription():
-    """Flag on OperatorOrganizationRole but no subscription for the queried service → no access."""
+    """Flag on OperatorOrganizationRole but no subscription for the queried
+    service → no domains for that service (empty list)."""
     user = factories.UserFactory(email="admin@operator.fr")
     client = APIClient()
     client.force_login(user)
@@ -1067,7 +1070,9 @@ def test_operator_admin_passthrough_requires_active_service_subscription():
         client, queried_service, organization.siret, account_email="admin@operator.fr"
     )
     assert response.status_code == 200
-    assert "can_admin_maildomains" not in response.json()["entitlements"]
+    # The subscription is for another service, so no domains for this service —
+    # but the field is present (empty) since the Messages resolver always runs.
+    assert response.json()["entitlements"]["can_admin_maildomains"] == []
 
 
 def test_operator_admin_passthrough_combined_with_account_admin():
@@ -1120,7 +1125,11 @@ def test_operator_admin_passthrough_combined_with_account_admin():
 
 
 def test_operator_admin_passthrough_email_must_match_exactly():
-    """Email match is exact — different casing in User.email won't match."""
+    """Email match is exact — different casing in User.email won't match.
+
+    But when the entitlements request sends the account_email with the exact
+    same casing as User.email, it matches and returns the admin domains.
+    """
     user = factories.UserFactory(email="Admin@Operator.FR")
     client = APIClient()
     client.force_login(user)
@@ -1148,3 +1157,159 @@ def test_operator_admin_passthrough_email_must_match_exactly():
     )
     assert response.status_code == 200
     assert response.json()["entitlements"]["can_admin_maildomains"] == []
+
+    # But the exact same casing as User.email matches and returns the domains.
+    response = _entitlements_request(
+        client, service, organization.siret, account_email="Admin@Operator.FR"
+    )
+    assert response.status_code == 200
+    assert response.json()["entitlements"]["can_admin_maildomains"] == ["commune.fr"]
+
+
+def test_operator_admin_passthrough_when_queried_org_has_no_subscription():
+    """Regression (production SIDEC case): a user who is operator-admin of
+    *other* organizations with active Messages must still receive
+    can_admin_maildomains even when the organization actually being queried has
+    no Messages subscription of its own.
+
+    Before the fix, the admin resolver only ran when the queried org had its own
+    active subscription, so this returned no can_admin_maildomains at all.
+    """
+    user = factories.UserFactory(email="admin@operator.fr")
+    client = APIClient()
+    client.force_login(user)
+
+    operator = factories.OperatorFactory()
+    factories.UserOperatorRoleFactory(user=user, operator=operator)
+
+    # The organization actually being queried (e.g. the operator's own org) has
+    # NO Messages subscription.
+    queried_org = factories.OrganizationFactory(siret="25390109400016")
+
+    # A *different* organization the operator manages, with active Messages and
+    # the admin passthrough flag on.
+    managed_org = factories.OrganizationFactory(siret="12345678900001")
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator,
+        organization=managed_org,
+        operator_admins_have_admin_role=True,
+    )
+
+    service = _make_messages_service()
+    factories.ServiceSubscriptionFactory(
+        organization=managed_org,
+        service=service,
+        operator=operator,
+        metadata={"domains": ["commune.fr"]},
+    )
+
+    response = _entitlements_request(
+        client, service, queried_org.siret, account_email="admin@operator.fr"
+    )
+    assert response.status_code == 200
+    entitlements = response.json()["entitlements"]
+    # The queried org itself is not activated...
+    assert entitlements["can_access"] is False
+    # ...but the cross-org admin domains are still surfaced.
+    assert entitlements["can_admin_maildomains"] == ["commune.fr"]
+
+
+def test_account_admin_domains_when_queried_org_has_no_subscription():
+    """A service-admin in one organization gets that org's Messages domains even
+    when the queried organization has no subscription of its own."""
+    user = factories.UserFactory(email="admin@example.com")
+    client = APIClient()
+    client.force_login(user)
+
+    operator = factories.OperatorFactory()
+
+    # Queried org has no subscription at all.
+    queried_org = factories.OrganizationFactory(siret="25390109400016")
+
+    # Managed org has active Messages, and the user is a service-admin there.
+    managed_org = factories.OrganizationFactory(siret="12345678900001")
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=managed_org
+    )
+
+    service = _make_messages_service()
+    factories.ServiceSubscriptionFactory(
+        organization=managed_org,
+        service=service,
+        operator=operator,
+        metadata={"domains": ["managed.fr"]},
+    )
+    account = factories.AccountFactory(
+        organization=managed_org,
+        type="user",
+        external_id="",
+        email="admin@example.com",
+        roles=[],
+    )
+    account.service_links.create(service=service, role="admin")
+
+    response = _entitlements_request(
+        client, service, queried_org.siret, account_email="admin@example.com"
+    )
+    assert response.status_code == 200
+    assert response.json()["entitlements"]["can_admin_maildomains"] == ["managed.fr"]
+
+
+def test_non_messages_admin_resolver_not_run_without_active_subscription():
+    """Scoping guard: for a non-Messages service, the admin resolver is NOT
+    cross-org, so it must NOT run when the queried org has no active
+    subscription. This proves the fix is scoped to Messages only and does not
+    change behavior for other services (e.g. service_id pointing at adc/esd).
+    """
+    user = factories.UserFactory(email="contact@commune.fr")
+    client = APIClient()
+    client.force_login(user)
+
+    # adc uses ExtendedAdminEntitlementResolver, which would return is_admin=True
+    # via the population fallback (population < threshold) *if* it ran — so if
+    # is_admin is absent, we know the resolver did not run.
+    service = factories.ServiceFactory(
+        type="adc",
+        config={"entitlements_api_key": "test_token"},
+    )
+
+    organization = factories.OrganizationFactory(
+        siret="12345678900001",
+        population=100,  # under the auto-admin population threshold
+    )
+    # No subscription for this service → the queried org is not activated.
+
+    response = _entitlements_request(
+        client, service, organization.siret, account_email="contact@commune.fr"
+    )
+    assert response.status_code == 200
+    entitlements = response.json()["entitlements"]
+    assert entitlements["can_access"] is False
+    # The (non-cross-org) admin resolver did not run: no admin fields leak in.
+    assert "is_admin" not in entitlements
+    assert "can_admin_maildomains" not in entitlements
+
+
+def test_messages_admin_resolver_runs_without_active_subscription_flag():
+    """The Messages admin resolver is flagged to run without an active
+    subscription; the base and extended resolvers are not."""
+    from core.entitlements.resolvers import (  # pylint: disable=import-outside-toplevel
+        get_admin_entitlement_resolver,
+    )
+
+    messages_service = factories.ServiceFactory(type="messages")
+    adc_service = factories.ServiceFactory(type="adc")
+    other_service = factories.ServiceFactory(type="some-other-type")
+
+    assert (
+        get_admin_entitlement_resolver(messages_service).runs_without_active_subscription
+        is True
+    )
+    assert (
+        get_admin_entitlement_resolver(adc_service).runs_without_active_subscription
+        is False
+    )
+    assert (
+        get_admin_entitlement_resolver(other_service).runs_without_active_subscription
+        is False
+    )

--- a/src/backend/core/tests/api/test_entitlements_messages_admin.py
+++ b/src/backend/core/tests/api/test_entitlements_messages_admin.py
@@ -7,6 +7,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from core import factories
+from core.entitlements.resolvers import get_admin_entitlement_resolver
 from core.tests.utils import assert_equals_partial
 
 pytestmark = pytest.mark.django_db
@@ -1293,10 +1294,6 @@ def test_non_messages_admin_resolver_not_run_without_active_subscription():
 def test_messages_admin_resolver_runs_without_active_subscription_flag():
     """The Messages admin resolver is flagged to run without an active
     subscription; the base and extended resolvers are not."""
-    from core.entitlements.resolvers import (  # pylint: disable=import-outside-toplevel
-        get_admin_entitlement_resolver,
-    )
-
     messages_service = factories.ServiceFactory(type="messages")
     adc_service = factories.ServiceFactory(type="adc")
     other_service = factories.ServiceFactory(type="some-other-type")

--- a/src/backend/core/tests/api/test_external_service_api.py
+++ b/src/backend/core/tests/api/test_external_service_api.py
@@ -223,6 +223,57 @@ def test_service_api_key_cannot_list_other_service_entitlements():
     assert response.status_code == 403
 
 
+# --- Services list tests ---
+
+
+def test_service_api_key_can_list_services():
+    """A service key can list the services for a managed organization."""
+    client, operator, service, organization = _setup_service_with_key()
+
+    response = client.get(
+        f"/api/v1.0/operators/{operator.id}/organizations/{organization.id}/services/"
+    )
+    assert response.status_code == 200
+    returned_ids = {str(result["id"]) for result in response.json()["results"]}
+    assert str(service.id) in returned_ids
+
+
+def test_operator_api_key_can_list_services():
+    """An operator key can list the services for a managed organization."""
+    operator = factories.OperatorFactory()
+    api_key = "test-operator-api-key-services"
+    operator.external_management_api_key = api_key
+    operator.save()
+
+    service = factories.ServiceFactory(type="test_service")
+    factories.OperatorServiceConfigFactory(operator=operator, service=service)
+    organization = factories.OrganizationFactory()
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=organization
+    )
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {api_key}")
+
+    response = client.get(
+        f"/api/v1.0/operators/{operator.id}/organizations/{organization.id}/services/"
+    )
+    assert response.status_code == 200
+    returned_ids = {str(result["id"]) for result in response.json()["results"]}
+    assert str(service.id) in returned_ids
+
+
+def test_service_api_key_cannot_list_services_unmanaged_organization():
+    """A service key cannot list services for an organization not managed by the operator."""
+    client, operator, _service, _organization = _setup_service_with_key()
+    unmanaged_org = factories.OrganizationFactory()
+
+    response = client.get(
+        f"/api/v1.0/operators/{operator.id}/organizations/{unmanaged_org.id}/services/"
+    )
+    assert response.status_code == 403
+
+
 # --- Access denied tests ---
 
 

--- a/src/backend/core/tests/api/test_external_service_api.py
+++ b/src/backend/core/tests/api/test_external_service_api.py
@@ -274,6 +274,33 @@ def test_service_api_key_cannot_list_services_unmanaged_organization():
     assert response.status_code == 403
 
 
+def test_service_api_key_cannot_list_services_unconfigured_operator():
+    """A service key cannot list services for an operator without OperatorServiceConfig.
+
+    Exercises ServiceExternalManagementPermission's missing-OperatorServiceConfig
+    branch on the /services/ endpoint (no service_id in the URL).
+    """
+    api_key = "test-service-api-key-services-unconfigured"
+    service = factories.ServiceFactory(type="test_service")
+    service.external_management_api_key = api_key
+    service.save()
+
+    # Operator manages the org but has NO OperatorServiceConfig for this service.
+    other_operator = factories.OperatorFactory()
+    organization = factories.OrganizationFactory()
+    factories.OperatorOrganizationRoleFactory(
+        operator=other_operator, organization=organization
+    )
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {api_key}")
+
+    response = client.get(
+        f"/api/v1.0/operators/{other_operator.id}/organizations/{organization.id}/services/"
+    )
+    assert response.status_code == 403
+
+
 # --- Access denied tests ---
 
 

--- a/src/frontend/src/features/i18n/translations.json
+++ b/src/frontend/src/features/i18n/translations.json
@@ -96,13 +96,6 @@
                   "contact_support": "Si vous souhaitez utiliser d'autres domaines, veuillez contacter le support ANCT."
                 }
               },
-              "admins": {
-                "label": "Administrateurs",
-                "service_count": "{{count}} pour ce service",
-                "global_count_one": "{{count}} global",
-                "global_count_other": "{{count}} globaux",
-                "and": "et"
-              },
               "entitlements": {
                 "messages_storage": {
                   "max_storage": {
@@ -126,6 +119,14 @@
                 }
               }
             }
+          },
+          "admins": {
+            "label": "Administrateurs",
+            "service_count": "{{count}} pour ce service",
+            "global_count_one": "{{count}} global",
+            "global_count_other": "{{count}} globaux",
+            "and": "et",
+            "operator_admins_note": "Les administrateurs de l'opérateur ont aussi un rôle d'administrateur sur ce service."
           },
           "extended_admin": {
             "label": "Rôles d'administration",

--- a/src/frontend/src/features/ui/components/service/ServiceAdminsFooter.tsx
+++ b/src/frontend/src/features/ui/components/service/ServiceAdminsFooter.tsx
@@ -17,7 +17,8 @@ export const ServiceAdminsFooter = (props: {
   const { data: adminCount } = useServiceAdminCount(
     operatorId,
     props.organization.id,
-    props.service.id
+    props.service.id,
+    !props.hideServiceCount
   );
 
   const serviceAdminCount = adminCount?.serviceCount ?? 0;

--- a/src/frontend/src/features/ui/components/service/ServiceAdminsFooter.tsx
+++ b/src/frontend/src/features/ui/components/service/ServiceAdminsFooter.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+
+import { Organization, Service } from "@/features/api/Repository";
+import { useOperatorContext } from "@/features/layouts/components/GlobalLayout";
+import { useServiceAdminCount } from "@/hooks/useQueries";
+
+const PREFIX = "organizations.services.admins";
+
+export const ServiceAdminsFooter = (props: {
+  organization: Organization;
+  service: Service;
+  hideServiceCount?: boolean;
+}) => {
+  const { t } = useTranslation();
+  const { operatorId } = useOperatorContext();
+  const { data: adminCount } = useServiceAdminCount(
+    operatorId,
+    props.organization.id,
+    props.service.id
+  );
+
+  const serviceAdminCount = adminCount?.serviceCount ?? 0;
+  const globalAdminCount = adminCount?.globalCount ?? 0;
+  const showOperatorAdminsNote =
+    props.organization.operator_admins_have_admin_role === true;
+
+  const getAccountsUrl = (role: string) =>
+    `/operators/${operatorId}/organizations/${props.organization.id}?tab=accounts&role=${encodeURIComponent(role)}`;
+
+  return (
+    <div className="dc__service__admins-summary">
+      <div>
+        {t(`${PREFIX}.label`)} :{" "}
+        {!props.hideServiceCount && (
+          <>
+            <Link
+              href={getAccountsUrl(`service.${props.service.id}.admin`)}
+              className="dc__service__admins-summary__link"
+            >
+              {t(`${PREFIX}.service_count`, { count: serviceAdminCount })}
+            </Link>
+            {" "}{t(`${PREFIX}.and`)}{" "}
+          </>
+        )}
+        <Link
+          href={getAccountsUrl("org.admin")}
+          className="dc__service__admins-summary__link"
+        >
+          {t(`${PREFIX}.global_count`, { count: globalAdminCount })}
+        </Link>
+      </div>
+      {showOperatorAdminsNote && (
+        <div className="dc__service__admins-summary__note">
+          {t(`${PREFIX}.operator_admins_note`)}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/frontend/src/features/ui/components/service/implementations/ExtendedAdminServiceBlock.tsx
+++ b/src/frontend/src/features/ui/components/service/implementations/ExtendedAdminServiceBlock.tsx
@@ -7,6 +7,7 @@ import {
   useServiceBlock,
 } from "@/features/ui/components/service/ServiceBlock";
 import { ServiceAttribute } from "../ServiceAttribute";
+import { ServiceAdminsFooter } from "../ServiceAdminsFooter";
 import { Trans, useTranslation } from "react-i18next";
 import {
   Button,
@@ -99,6 +100,13 @@ export const ExtendedAdminServiceBlock = (props: {
             interactive={!blockProps.isManagedByOtherOperator}
           />
         </div>
+      }
+      footer={
+        <ServiceAdminsFooter
+          organization={props.organization}
+          service={props.service}
+          hideServiceCount={effectiveMode === ADMIN_MODE_ALL}
+        />
       }
     />
   );

--- a/src/frontend/src/features/ui/components/service/implementations/MessagesServiceBlock.tsx
+++ b/src/frontend/src/features/ui/components/service/implementations/MessagesServiceBlock.tsx
@@ -8,14 +8,14 @@ import {
   useServiceBlock,
 } from "@/features/ui/components/service/ServiceBlock";
 import { ServiceAttribute } from "../ServiceAttribute";
+import { ServiceAdminsFooter } from "../ServiceAdminsFooter";
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import { useMessagesAdminCount, useOrganizationServices } from "@/hooks/useQueries";
+import { useOrganizationServices } from "@/hooks/useQueries";
 import { useOperatorContext } from "@/features/layouts/components/GlobalLayout";
 import { useAuth } from "@/features/auth/Auth";
 import { Icon, IconSize } from "@gouvfr-lasuite/ui-kit";
 import { useModal } from "@openfun/cunningham-react";
-import Link from "next/link";
 import { MutateOptions } from "@tanstack/react-query";
 import { DomainSelectorModal } from "../DomainSelectorModal";
 
@@ -43,13 +43,6 @@ export const MessagesServiceBlock = (props: {
     return undefined;
   }, [props.service.subscription?.metadata?.domains]);
 
-  // Fetch admin count
-  const { data: adminCount } = useMessagesAdminCount(
-    operatorId,
-    props.organization.id,
-    props.service.id
-  );
-
   // Fetch services to get ProConnect domains as default
   const { data: services } = useOrganizationServices(
     operatorId,
@@ -75,10 +68,6 @@ export const MessagesServiceBlock = (props: {
   const domains = savedDomains !== undefined ? savedDomains : proConnectDomains;
   const hasDomains = domains.length > 0;
 
-  const getAccountsUrl = (role: string) => {
-    return `/operators/${operatorId}/organizations/${props.organization.id}?tab=accounts&role=${encodeURIComponent(role)}`;
-  };
-
   // Block activation if no domains are configured
   const canActivateSubscription = async () => {
     if (!hasDomains) {
@@ -87,10 +76,6 @@ export const MessagesServiceBlock = (props: {
     }
     return true;
   };
-
-  const serviceAdminCount = adminCount?.serviceCount ?? 0;
-  const globalAdminCount = adminCount?.globalCount ?? 0;
-
 
   const handleDomainsChange = (
     newDomains: string[],
@@ -158,22 +143,10 @@ export const MessagesServiceBlock = (props: {
         </div>
       }
       footer={
-        <div className="dc__service__admins-summary">
-          {t(`${PREFIX}.admins.label`)} :{" "}
-          <Link
-            href={getAccountsUrl(`service.${props.service.id}.admin`)}
-            className="dc__service__admins-summary__link"
-          >
-            {t(`${PREFIX}.admins.service_count`, { count: serviceAdminCount })}
-          </Link>
-          {" "}{t(`${PREFIX}.admins.and`)}{" "}
-          <Link
-            href={getAccountsUrl("org.admin")}
-            className="dc__service__admins-summary__link"
-          >
-            {t(`${PREFIX}.admins.global_count`, { count: globalAdminCount })}
-          </Link>
-        </div>
+        <ServiceAdminsFooter
+          organization={props.organization}
+          service={props.service}
+        />
       }
     />
   );

--- a/src/frontend/src/hooks/useQueries.tsx
+++ b/src/frontend/src/hooks/useQueries.tsx
@@ -299,32 +299,39 @@ export const useMutationUpdateAccountServiceLink = () => {
 export const useServiceAdminCount = (
   operatorId: string,
   organizationId: string,
-  serviceId: string
+  serviceId: string,
+  includeServiceCount: boolean = true
 ) => {
   return useQuery({
+    // Nested under the "accounts" namespace so existing account mutations
+    // (which invalidate [..., "accounts"]) also refresh these counts.
     queryKey: [
       "operators",
       operatorId,
       "organizations",
       organizationId,
-      "serviceAdminCount",
+      "accounts",
       serviceId,
+      "serviceAdminCount",
+      includeServiceCount,
     ],
     queryFn: async () => {
-      // Fetch both admin counts in parallel
+      // Only fetch the per-service count when it will actually be displayed.
       const [globalAdmins, serviceAdmins] = await Promise.all([
         getOrganizationAccounts(operatorId, organizationId, {
           role: "org.admin",
         }),
-        getOrganizationAccounts(operatorId, organizationId, {
-          role: `service.${serviceId}.admin`,
-        }),
+        includeServiceCount
+          ? getOrganizationAccounts(operatorId, organizationId, {
+              role: `service.${serviceId}.admin`,
+            })
+          : Promise.resolve(null),
       ]);
 
       // Use count field for total count (handles pagination)
       return {
         globalCount: globalAdmins.count,
-        serviceCount: serviceAdmins.count,
+        serviceCount: serviceAdmins?.count ?? 0,
       };
     },
     enabled: !!operatorId && !!organizationId && !!serviceId,

--- a/src/frontend/src/hooks/useQueries.tsx
+++ b/src/frontend/src/hooks/useQueries.tsx
@@ -296,7 +296,7 @@ export const useMutationUpdateAccountServiceLink = () => {
   });
 };
 
-export const useMessagesAdminCount = (
+export const useServiceAdminCount = (
   operatorId: string,
   organizationId: string,
   serviceId: string
@@ -307,7 +307,7 @@ export const useMessagesAdminCount = (
       operatorId,
       "organizations",
       organizationId,
-      "messagesAdminCount",
+      "serviceAdminCount",
       serviceId,
     ],
     queryFn: async () => {

--- a/src/frontend/src/pages/operators/[operator_id]/organizations/index.scss
+++ b/src/frontend/src/pages/operators/[operator_id]/organizations/index.scss
@@ -531,6 +531,11 @@
       color: var(--c--theme--colors--primary-700);
     }
   }
+
+  &__note {
+    font-style: italic;
+    margin-top: 2px;
+  }
 }
 
 .dc__domain-selector {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * External service API keys can now authenticate and list services for managed organizations.
* **Security / Access Control**
  * Broadened external management access rules to allow service management permissions in addition to operator/organization access.
  * Improved admin entitlement resolution to support cross-organization “passthrough” when subscriptions are inactive or missing.
* **UI Improvements**
  * Added a dedicated admins summary footer showing service-level vs global admin counts, including an operator-admin note when applicable.
* **Search / i18n**
  * Expanded organization admin search to include SIRET, and updated admin-related translations layout.
* **Tests**
  * Added and expanded authorization and entitlement regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->