### PR TITLE
✨(backend) expose entitlements and metrics attributes

### DIFF
--- a/src/backend/core/api/viewsets/entitlements.py
+++ b/src/backend/core/api/viewsets/entitlements.py
@@ -193,6 +193,7 @@ class EntitlementView(APIView):
         # This entitlement should always be resolved.
         access_resolver = get_access_entitlement_resolver(service)
         entitlements_data = {**access_resolver.resolve(entitlement_context)}
+        metrics_data = {}
 
         if service_subscription and service_subscription.is_active:
             operator_data = EntitlementOperatorSerializer(
@@ -259,6 +260,7 @@ class EntitlementView(APIView):
                     {**entitlement_context, "entitlements": entitlements_of_type}
                 )
                 entitlements_data = {**entitlements_data, **entitlement_data}
+                metrics_data = {**metrics_data, **resolver.metrics_data}
 
             # Resolve admin entitlement.
             entitlements_data = {
@@ -276,12 +278,6 @@ class EntitlementView(APIView):
                 potential_operators_data = _find_potential_operators(
                     organization, service
                 )
-
-        # Separate metric fields from entitlements.
-        metrics_data = {}
-        for key in ("storage_used",):
-            if key in entitlements_data:
-                metrics_data[key] = entitlements_data.pop(key)
 
         organization_data = None
         if organization:
@@ -311,6 +307,7 @@ class EntitlementView(APIView):
             "organization": organization_data,
             "operator": operator_data,
             "entitlements": entitlements_data,
+            "metrics": metrics_data,
         }
         if potential_operators_data is not None:
             response_data["potentialOperators"] = potential_operators_data

--- a/src/backend/core/entitlements/resolvers/drive_storage_entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/drive_storage_entitlement_resolver.py
@@ -40,3 +40,11 @@ class DriveStorageEntitlementResolver(EntitlementResolver):
                 "key": "storage_used",
             },
         )
+
+    def _expose_entitlement_attributes(self, context, entitlement):
+        """
+        Expose the attributes of the entitlement.
+        """
+        return {
+            "max_storage": entitlement.config.get("max_storage") or 0,
+        }

--- a/src/backend/core/entitlements/resolvers/entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/entitlement_resolver.py
@@ -95,6 +95,9 @@ class EntitlementResolver:
 
     resolve_level_prefix = ""
 
+    def __init__(self):
+        self.metrics_data = {}
+
     def resolve(self, context):
         """
         Resolve the metric based entitlements according to their priority.
@@ -157,27 +160,22 @@ class EntitlementResolver:
         if entitlement_organization:
             organization_metric = self._get_metric(context, entitlement_organization)
 
-        attributes[self.resolve_level_prefix + "_entitlement_account_override"] = (
-            self._expose_entitlement_attributes(context, entitlement_account_override)
-            if entitlement_account_override
-            else None
+        self._include_entitlement_attributes(
+            attributes, context, entitlement_account_override, "account_override"
         )
-        attributes[self.resolve_level_prefix + "_entitlement_account"] = (
-            self._expose_entitlement_attributes(context, entitlement_account)
-            if entitlement_account
-            else None
+        self._include_entitlement_attributes(
+            attributes, context, entitlement_account, "account"
         )
-        attributes[self.resolve_level_prefix + "_entitlement_organization"] = (
-            self._expose_entitlement_attributes(context, entitlement_organization)
-            if entitlement_organization
-            else None
+        self._include_entitlement_attributes(
+            attributes, context, entitlement_organization, "organization"
         )
-        attributes[self.resolve_level_prefix + "_metric_account"] = (
+
+        self.metrics_data["account"] = (
             self._expose_metric_attributes(context, account_metric)
             if account_metric
             else None
         )
-        attributes[self.resolve_level_prefix + "_metric_organization"] = (
+        self.metrics_data["organization"] = (
             self._expose_metric_attributes(context, organization_metric)
             if organization_metric
             else None
@@ -282,6 +280,16 @@ class EntitlementResolver:
         """
         pass
 
+    def _include_entitlement_attributes(self, attributes, context, entitlement, level):
+        entitlement_exposed_attributes = (
+            self._expose_entitlement_attributes(context, entitlement)
+            if entitlement
+            else None
+        )
+        if entitlement_exposed_attributes:
+            for key, value in entitlement_exposed_attributes.items():
+                attributes[f"{key}_{level}"] = value
+
     def _expose_entitlement_attributes(self, context, entitlement):
         """
         Expose the attributes of the entitlement.
@@ -293,8 +301,7 @@ class EntitlementResolver:
         Expose the attributes of the metric.
         """
         return {
-            "key": metric.key,
-            "value": metric.value,
+            metric.key: metric.value,
         }
 
     def _log_metric_not_found_warning(self, context, entitlement):

--- a/src/backend/core/entitlements/resolvers/entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/entitlement_resolver.py
@@ -139,38 +139,87 @@ class EntitlementResolver:
 
         entitlements = get_entitlements_by_priority(context["entitlements"])
         entitlement_account = entitlements.get("account")
+        entitlement_account_override = entitlements.get("account_override")
+        entitlement_organization = entitlements.get("organization")
+
+        attributes = {}
+        account_metric = None
+        organization_metric = None
+
+        # Expose entitlements and metrics attributes.
+        if entitlement_account_override or entitlement_account:
+            account_metric = self._get_metric(
+                context,
+                entitlement_account_override
+                if entitlement_account_override
+                else entitlement_account,
+            )
+        if entitlement_organization:
+            organization_metric = self._get_metric(context, entitlement_organization)
+
+        attributes[self.resolve_level_prefix + "_entitlement_account_override"] = (
+            self._expose_entitlement_attributes(context, entitlement_account_override)
+            if entitlement_account_override
+            else None
+        )
+        attributes[self.resolve_level_prefix + "_entitlement_account"] = (
+            self._expose_entitlement_attributes(context, entitlement_account)
+            if entitlement_account
+            else None
+        )
+        attributes[self.resolve_level_prefix + "_entitlement_organization"] = (
+            self._expose_entitlement_attributes(context, entitlement_organization)
+            if entitlement_organization
+            else None
+        )
+        attributes[self.resolve_level_prefix + "_metric_account"] = (
+            self._expose_metric_attributes(context, account_metric)
+            if account_metric
+            else None
+        )
+        attributes[self.resolve_level_prefix + "_metric_organization"] = (
+            self._expose_metric_attributes(context, organization_metric)
+            if organization_metric
+            else None
+        )
+
+        # Resolve entitlements.
 
         # The account override is the highest priority entitlement. Whether it
         # complies or not, we will return the result.
-        if entitlement_account_override := entitlements.get("account_override"):
-            metric = self._get_metric(context, entitlement_account_override)
-            _, attributes = self._resolve_entitlement(
-                context, entitlement_account_override, metric
+        if entitlement_account_override:
+            _, entitlement_attributes = self._resolve_entitlement(
+                context, entitlement_account_override, account_metric
             )
             return self._build_resolve_level(
-                attributes, f"{entitlement_account_override.account_type}_override"
+                {
+                    **attributes,
+                    **entitlement_attributes,
+                },
+                f"{entitlement_account_override.account_type}_override",
             )
 
         # If there is an organization entitlement, it should first resolve anyway
         # before the generic account entitlement.
-        if entitlement_organization := entitlements.get("organization"):
-            metric = self._get_metric(context, entitlement_organization)
-            compliant, attributes = self._resolve_entitlement(
-                context, entitlement_organization, metric
+        if entitlement_organization:
+            compliant, entitlement_attributes = self._resolve_entitlement(
+                context, entitlement_organization, organization_metric
             )
             # If there is an account entitlement and it this one does not comply, we can return directly.
             # Or if there is no account entitlement to run further, we can return directly in anyway.
             if not compliant or not entitlement_account:
-                return self._build_resolve_level(attributes, "organization")
+                return self._build_resolve_level(
+                    {**attributes, **entitlement_attributes}, "organization"
+                )
 
         # If there is a generic account entitlement, it should be the last one to resolve.
         if entitlement_account:
-            metric = self._get_metric(context, entitlement_account)
-            compliant, attributes = self._resolve_entitlement(
-                context, entitlement_account, metric
+            compliant, entitlement_attributes = self._resolve_entitlement(
+                context, entitlement_account, account_metric
             )
             return self._build_resolve_level(
-                attributes, entitlement_account.account_type
+                {**attributes, **entitlement_attributes},
+                entitlement_account.account_type,
             )
 
         raise ValueError(
@@ -232,6 +281,21 @@ class EntitlementResolver:
 
         """
         pass
+
+    def _expose_entitlement_attributes(self, context, entitlement):
+        """
+        Expose the attributes of the entitlement.
+        """
+        return {}
+
+    def _expose_metric_attributes(self, context, metric):
+        """
+        Expose the attributes of the metric.
+        """
+        return {
+            "key": metric.key,
+            "value": metric.value,
+        }
 
     def _log_metric_not_found_warning(self, context, entitlement):
         """

--- a/src/backend/core/entitlements/resolvers/messages_storage_entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/messages_storage_entitlement_resolver.py
@@ -53,3 +53,11 @@ class MessagesStorageEntitlementResolver(EntitlementResolver):
                 "key": "storage_used",
             },
         )
+
+    def _expose_entitlement_attributes(self, context, entitlement):
+        """
+        Expose the attributes of the entitlement.
+        """
+        return {
+            "max_storage": entitlement.config.get("max_storage") or 0,
+        }

--- a/src/backend/core/entitlements/resolvers/messages_storage_entitlement_resolver.py
+++ b/src/backend/core/entitlements/resolvers/messages_storage_entitlement_resolver.py
@@ -22,24 +22,16 @@ class MessagesStorageEntitlementResolver(EntitlementResolver):
         if max_storage == 0:
             return (
                 True,
-                {"can_store": True, "max_storage": 0, "storage_used": storage_used},
+                {"can_store": True},
             )
         if storage_used > max_storage:
             return (
                 False,
-                {
-                    "can_store": False,
-                    "max_storage": max_storage,
-                    "storage_used": storage_used,
-                },
+                {"can_store": False},
             )
         return (
             True,
-            {
-                "can_store": True,
-                "max_storage": max_storage,
-                "storage_used": storage_used,
-            },
+            {"can_store": True},
         )
 
     def _get_metric(self, context, entitlement):

--- a/src/backend/core/tests/api/test_entitlements.py
+++ b/src/backend/core/tests/api/test_entitlements.py
@@ -259,6 +259,7 @@ def test_api_entitlements_list_organization_not_found(webhook_server):
             "can_access": False,
             "can_access_reason": AccessEntitlementResolver.Reason.NO_ORGANIZATION,
         },
+        "metrics": {},
     }
 
 

--- a/src/backend/core/tests/api/test_entitlements_calendars.py
+++ b/src/backend/core/tests/api/test_entitlements_calendars.py
@@ -81,6 +81,7 @@ def test_api_entitlements_calendars_can_access_with_active_messages_subscription
         "entitlements": {
             "can_access": True,
         },
+        "metrics": {},
     }
 
 
@@ -117,6 +118,7 @@ def test_api_entitlements_calendars_can_access_without_messages_subscription():
             "can_access": False,
             "can_access_reason": CalendarsAccessEntitlementResolver.Reason.NOT_ACTIVATED,
         },
+        "metrics": {},
     }
 
 
@@ -175,6 +177,7 @@ def test_api_entitlements_calendars_can_access_no_organization():
             "can_access": False,
             "can_access_reason": CalendarsAccessEntitlementResolver.Reason.NO_ORGANIZATION,
         },
+        "metrics": {},
     }
 
 

--- a/src/backend/core/tests/api/test_entitlements_drive.py
+++ b/src/backend/core/tests/api/test_entitlements_drive.py
@@ -153,6 +153,7 @@ def test_api_entitlements_can_access_without_subscription(
             "can_upload": False,
             "can_upload_reason": AccessEntitlementResolver.Reason.NOT_ACTIVATED,
         },
+        "metrics": {},
     }
 
     # Create an inactive subscription to test that the user can still access the service.
@@ -188,6 +189,7 @@ def test_api_entitlements_can_access_without_subscription(
             "can_upload": False,
             "can_upload_reason": AccessEntitlementResolver.Reason.NOT_ACTIVATED,
         },
+        "metrics": {},
     }
 
 
@@ -304,20 +306,15 @@ def test_api_entitlements_user_can_upload(
                 "can_access": True,
                 "can_upload": True,
                 "can_upload_resolve_level": "user",
-                "can_upload_entitlement_account": {
-                    "max_storage": 1000 * 1000 * 1000 * 5,
+                "max_storage_account": 1000 * 1000 * 1000 * 5,
+                "max_storage_organization": 1000 * 1000 * 1000 * 10,
+            },
+            "metrics": {
+                "account": {
+                    "storage_used": 500,
                 },
-                "can_upload_entitlement_organization": {
-                    "max_storage": 1000 * 1000 * 1000 * 10,
-                },
-                "can_upload_entitlement_account_override": None,
-                "can_upload_metric_account": {
-                    "key": "storage_used",
-                    "value": 500,
-                },
-                "can_upload_metric_organization": {
-                    "key": "storage_used",
-                    "value": 1000,
+                "organization": {
+                    "storage_used": 1000,
                 },
             },
         },
@@ -427,22 +424,17 @@ def test_api_entitlements_user_can_upload(
             "entitlements": {
                 "can_upload": False,
                 "can_upload_resolve_level": "organization",
-                "can_upload_entitlement_account": {
-                    "max_storage": 1000 * 1000 * 1000 * 5,
-                },
-                "can_upload_entitlement_organization": {
-                    "max_storage": 1000 * 1000 * 1000 * 10,
-                },
-                "can_upload_entitlement_account_override": None,
-                "can_upload_metric_account": {
-                    "key": "storage_used",
-                    "value": 1000 * 1000 * 1000 * 50 + 1,
-                },
-                "can_upload_metric_organization": {
-                    "key": "storage_used",
-                    "value": 1000 * 1000 * 1000 * 50 + 1,
-                },
+                "max_storage_account": 1000 * 1000 * 1000 * 5,
+                "max_storage_organization": 1000 * 1000 * 1000 * 10,
                 "can_access": True,
+            },
+            "metrics": {
+                "account": {
+                    "storage_used": 1000 * 1000 * 1000 * 50 + 1,
+                },
+                "organization": {
+                    "storage_used": 1000 * 1000 * 1000 * 50 + 1,
+                },
             },
         },
     )
@@ -626,20 +618,15 @@ def test_api_entitlements_organization_can_upload(
                 "can_access": True,
                 "can_upload": can_upload,
                 "can_upload_resolve_level": resolve_level,
-                "can_upload_entitlement_account": {
-                    "max_storage": 1000 * 1000 * 1000 * 5,
+                "max_storage_account": 1000 * 1000 * 1000 * 5,
+                "max_storage_organization": 1000 * 1000 * 1000 * 10,
+            },
+            "metrics": {
+                "account": {
+                    "storage_used": user_storage_used,
                 },
-                "can_upload_entitlement_organization": {
-                    "max_storage": 1000 * 1000 * 1000 * 10,
-                },
-                "can_upload_entitlement_account_override": None,
-                "can_upload_metric_account": {
-                    "key": "storage_used",
-                    "value": user_storage_used,
-                },
-                "can_upload_metric_organization": {
-                    "key": "storage_used",
-                    "value": organization_storage_used,
+                "organization": {
+                    "storage_used": organization_storage_used,
                 },
             },
         },
@@ -805,16 +792,13 @@ def test_api_entitlements_user_override_can_upload(
                 "can_access": True,
                 "can_upload": can_upload_before_override,
                 "can_upload_resolve_level": "user",
-                "can_upload_entitlement_account": {
-                    "max_storage": 500,
+                "max_storage_account": 500,
+            },
+            "metrics": {
+                "account": {
+                    "storage_used": user_storage_used,
                 },
-                "can_upload_entitlement_organization": None,
-                "can_upload_entitlement_account_override": None,
-                "can_upload_metric_account": {
-                    "key": "storage_used",
-                    "value": user_storage_used,
-                },
-                "can_upload_metric_organization": None,
+                "organization": None,
             },
         },
     )
@@ -858,18 +842,14 @@ def test_api_entitlements_user_override_can_upload(
                 "can_access": True,
                 "can_upload": can_upload,
                 "can_upload_resolve_level": "user_override",
-                "can_upload_entitlement_account": {
-                    "max_storage": 500,
+                "max_storage_account": 500,
+                "max_storage_account_override": override_max_storage,
+            },
+            "metrics": {
+                "account": {
+                    "storage_used": user_storage_used,
                 },
-                "can_upload_entitlement_organization": None,
-                "can_upload_entitlement_account_override": {
-                    "max_storage": override_max_storage,
-                },
-                "can_upload_metric_account": {
-                    "key": "storage_used",
-                    "value": user_storage_used,
-                },
-                "can_upload_metric_organization": None,
+                "organization": None,
             },
         },
     )
@@ -937,16 +917,13 @@ def test_api_entitlements_user_override_can_upload(
                 "can_access": True,
                 "can_upload": can_upload_before_override,
                 "can_upload_resolve_level": "user",
-                "can_upload_entitlement_account": {
-                    "max_storage": 500,
+                "max_storage_account": 500,
+            },
+            "metrics": {
+                "account": {
+                    "storage_used": user_storage_used,
                 },
-                "can_upload_entitlement_organization": None,
-                "can_upload_entitlement_account_override": None,
-                "can_upload_metric_account": {
-                    "key": "storage_used",
-                    "value": user_storage_used,
-                },
-                "can_upload_metric_organization": None,
+                "organization": None,
             },
         },
     )
@@ -1061,14 +1038,13 @@ def test_api_entitlements_list_unlimited_storage(
                 "can_access": True,
                 "can_upload": True,  # Should be True even with high usage when max_storage is 0 or missing
                 "can_upload_resolve_level": "user",
-                "can_upload_entitlement_account_override": None,
-                "can_upload_entitlement_account": {"max_storage": 0},
-                "can_upload_entitlement_organization": None,
-                "can_upload_metric_account": {
-                    "key": "storage_used",
-                    "value": storage_used,
+                "max_storage_account": 0,
+            },
+            "metrics": {
+                "account": {
+                    "storage_used": storage_used,
                 },
-                "can_upload_metric_organization": None,
+                "organization": None,
             },
         },
     )

--- a/src/backend/core/tests/api/test_entitlements_drive.py
+++ b/src/backend/core/tests/api/test_entitlements_drive.py
@@ -304,6 +304,21 @@ def test_api_entitlements_user_can_upload(
                 "can_access": True,
                 "can_upload": True,
                 "can_upload_resolve_level": "user",
+                "can_upload_entitlement_account": {
+                    "max_storage": 1000 * 1000 * 1000 * 5,
+                },
+                "can_upload_entitlement_organization": {
+                    "max_storage": 1000 * 1000 * 1000 * 10,
+                },
+                "can_upload_entitlement_account_override": None,
+                "can_upload_metric_account": {
+                    "key": "storage_used",
+                    "value": 500,
+                },
+                "can_upload_metric_organization": {
+                    "key": "storage_used",
+                    "value": 1000,
+                },
             },
         },
     )
@@ -389,7 +404,6 @@ def test_api_entitlements_user_can_upload(
         },
         status=200,
     )
-
     # Test that we cannot upload more than the max storage size
     response = client.get(
         "/api/v1.0/entitlements/",
@@ -412,6 +426,22 @@ def test_api_entitlements_user_can_upload(
             },
             "entitlements": {
                 "can_upload": False,
+                "can_upload_resolve_level": "organization",
+                "can_upload_entitlement_account": {
+                    "max_storage": 1000 * 1000 * 1000 * 5,
+                },
+                "can_upload_entitlement_organization": {
+                    "max_storage": 1000 * 1000 * 1000 * 10,
+                },
+                "can_upload_entitlement_account_override": None,
+                "can_upload_metric_account": {
+                    "key": "storage_used",
+                    "value": 1000 * 1000 * 1000 * 50 + 1,
+                },
+                "can_upload_metric_organization": {
+                    "key": "storage_used",
+                    "value": 1000 * 1000 * 1000 * 50 + 1,
+                },
                 "can_access": True,
             },
         },
@@ -596,6 +626,21 @@ def test_api_entitlements_organization_can_upload(
                 "can_access": True,
                 "can_upload": can_upload,
                 "can_upload_resolve_level": resolve_level,
+                "can_upload_entitlement_account": {
+                    "max_storage": 1000 * 1000 * 1000 * 5,
+                },
+                "can_upload_entitlement_organization": {
+                    "max_storage": 1000 * 1000 * 1000 * 10,
+                },
+                "can_upload_entitlement_account_override": None,
+                "can_upload_metric_account": {
+                    "key": "storage_used",
+                    "value": user_storage_used,
+                },
+                "can_upload_metric_organization": {
+                    "key": "storage_used",
+                    "value": organization_storage_used,
+                },
             },
         },
     )
@@ -748,6 +793,7 @@ def test_api_entitlements_user_override_can_upload(
     )
     assert response.status_code == 200
     data = response.json()
+
     assert_equals_partial(
         data,
         {
@@ -759,6 +805,16 @@ def test_api_entitlements_user_override_can_upload(
                 "can_access": True,
                 "can_upload": can_upload_before_override,
                 "can_upload_resolve_level": "user",
+                "can_upload_entitlement_account": {
+                    "max_storage": 500,
+                },
+                "can_upload_entitlement_organization": None,
+                "can_upload_entitlement_account_override": None,
+                "can_upload_metric_account": {
+                    "key": "storage_used",
+                    "value": user_storage_used,
+                },
+                "can_upload_metric_organization": None,
             },
         },
     )
@@ -802,6 +858,18 @@ def test_api_entitlements_user_override_can_upload(
                 "can_access": True,
                 "can_upload": can_upload,
                 "can_upload_resolve_level": "user_override",
+                "can_upload_entitlement_account": {
+                    "max_storage": 500,
+                },
+                "can_upload_entitlement_organization": None,
+                "can_upload_entitlement_account_override": {
+                    "max_storage": override_max_storage,
+                },
+                "can_upload_metric_account": {
+                    "key": "storage_used",
+                    "value": user_storage_used,
+                },
+                "can_upload_metric_organization": None,
             },
         },
     )
@@ -869,6 +937,16 @@ def test_api_entitlements_user_override_can_upload(
                 "can_access": True,
                 "can_upload": can_upload_before_override,
                 "can_upload_resolve_level": "user",
+                "can_upload_entitlement_account": {
+                    "max_storage": 500,
+                },
+                "can_upload_entitlement_organization": None,
+                "can_upload_entitlement_account_override": None,
+                "can_upload_metric_account": {
+                    "key": "storage_used",
+                    "value": user_storage_used,
+                },
+                "can_upload_metric_organization": None,
             },
         },
     )
@@ -983,6 +1061,14 @@ def test_api_entitlements_list_unlimited_storage(
                 "can_access": True,
                 "can_upload": True,  # Should be True even with high usage when max_storage is 0 or missing
                 "can_upload_resolve_level": "user",
+                "can_upload_entitlement_account_override": None,
+                "can_upload_entitlement_account": {"max_storage": 0},
+                "can_upload_entitlement_organization": None,
+                "can_upload_metric_account": {
+                    "key": "storage_used",
+                    "value": storage_used,
+                },
+                "can_upload_metric_organization": None,
             },
         },
     )

--- a/src/backend/core/tests/api/test_entitlements_meet.py
+++ b/src/backend/core/tests/api/test_entitlements_meet.py
@@ -68,6 +68,7 @@ def test_api_entitlements_meet_can_create_with_active_subscription():
         "entitlements": {
             "can_create": True,
         },
+        "metrics": {},
     }
 
 
@@ -117,6 +118,7 @@ def test_api_entitlements_meet_can_create_without_subscription():
             "can_create": False,
             "can_create_reason": MeetAccessEntitlementResolver.Reason.NOT_ACTIVATED,
         },
+        "metrics": {},
     }
 
 
@@ -170,6 +172,7 @@ def test_api_entitlements_meet_can_create_with_inactive_subscription():
             "can_create": False,
             "can_create_reason": MeetAccessEntitlementResolver.Reason.NOT_ACTIVATED,
         },
+        "metrics": {},
     }
 
 
@@ -207,4 +210,5 @@ def test_api_entitlements_meet_can_create_no_organization():
             "can_create": False,
             "can_create_reason": MeetAccessEntitlementResolver.Reason.NO_ORGANIZATION,
         },
+        "metrics": {},
     }

--- a/src/backend/core/tests/api/test_entitlements_messages.py
+++ b/src/backend/core/tests/api/test_entitlements_messages.py
@@ -165,6 +165,14 @@ def test_api_entitlements_mailbox_can_store(
             "can_store_resolve_level": "mailbox",
             "max_storage": 1000,
             "can_admin_maildomains": [],
+            "can_store_entitlement_account_override": None,
+            "can_store_entitlement_account": {"max_storage": 1000},
+            "can_store_entitlement_organization": None,
+            "can_store_metric_account": {
+                "key": "storage_used",
+                "value": 500,
+            },
+            "can_store_metric_organization": None,
         },
         "metrics": {
             "storage_used": 500,
@@ -242,6 +250,14 @@ def test_api_entitlements_mailbox_can_store(
             "can_store_resolve_level": "mailbox",
             "max_storage": 1000,
             "can_admin_maildomains": [],
+            "can_store_entitlement_account_override": None,
+            "can_store_entitlement_account": {"max_storage": 1000},
+            "can_store_entitlement_organization": None,
+            "can_store_metric_account": {
+                "key": "storage_used",
+                "value": 1001,
+            },
+            "can_store_metric_organization": None,
         },
         "metrics": {
             "storage_used": 1001,
@@ -437,6 +453,17 @@ def test_api_entitlements_organization_can_store(
             "can_store_resolve_level": resolve_level,
             "max_storage": expected_max_storage,
             "can_admin_maildomains": [],
+            "can_store_entitlement_account_override": None,
+            "can_store_entitlement_account": {"max_storage": 1000},
+            "can_store_entitlement_organization": {"max_storage": 10000},
+            "can_store_metric_account": {
+                "key": "storage_used",
+                "value": mailbox_storage_used,
+            },
+            "can_store_metric_organization": {
+                "key": "storage_used",
+                "value": organization_storage_used,
+            },
         },
         "metrics": {
             "storage_used": expected_storage_used,
@@ -649,6 +676,17 @@ def test_api_entitlements_mailbox_override_can_store(
             "can_store_resolve_level": "mailbox",
             "max_storage": 500,
             "can_admin_maildomains": [],
+            "can_store_entitlement_account_override": None,
+            "can_store_entitlement_account": {"max_storage": 500},
+            "can_store_entitlement_organization": {"max_storage": 1000},
+            "can_store_metric_account": {
+                "key": "storage_used",
+                "value": mailbox_storage_used,
+            },
+            "can_store_metric_organization": {
+                "key": "storage_used",
+                "value": 800,
+            },
         },
         "metrics": {
             "storage_used": mailbox_storage_used,
@@ -702,6 +740,19 @@ def test_api_entitlements_mailbox_override_can_store(
             "can_store_resolve_level": "mailbox_override",
             "max_storage": override_max_storage,
             "can_admin_maildomains": [],
+            "can_store_entitlement_account_override": {
+                "max_storage": override_max_storage,
+            },
+            "can_store_entitlement_account": {"max_storage": 500},
+            "can_store_entitlement_organization": {"max_storage": 1000},
+            "can_store_metric_account": {
+                "key": "storage_used",
+                "value": mailbox_storage_used,
+            },
+            "can_store_metric_organization": {
+                "key": "storage_used",
+                "value": 800,
+            },
         },
         "metrics": {
             "storage_used": mailbox_storage_used,
@@ -808,6 +859,17 @@ def test_api_entitlements_mailbox_override_can_store(
             "can_store_resolve_level": "mailbox",
             "max_storage": 500,
             "can_admin_maildomains": [],
+            "can_store_entitlement_account_override": None,
+            "can_store_entitlement_account": {"max_storage": 500},
+            "can_store_entitlement_organization": {"max_storage": 1000},
+            "can_store_metric_account": {
+                "key": "storage_used",
+                "value": mailbox_storage_used,
+            },
+            "can_store_metric_organization": {
+                "key": "storage_used",
+                "value": 800,
+            },
         },
         "metrics": {
             "storage_used": mailbox_storage_used,
@@ -939,6 +1001,14 @@ def test_api_entitlements_list_unlimited_storage(
             "can_store_resolve_level": "mailbox",
             "max_storage": 0,
             "can_admin_maildomains": [],
+            "can_store_entitlement_account_override": None,
+            "can_store_entitlement_account": {"max_storage": 0},
+            "can_store_entitlement_organization": None,
+            "can_store_metric_account": {
+                "key": "storage_used",
+                "value": storage_used,
+            },
+            "can_store_metric_organization": None,
         },
         "metrics": {
             "storage_used": storage_used,

--- a/src/backend/core/tests/api/test_entitlements_messages.py
+++ b/src/backend/core/tests/api/test_entitlements_messages.py
@@ -163,19 +163,12 @@ def test_api_entitlements_mailbox_can_store(
             "can_access": True,
             "can_store": True,
             "can_store_resolve_level": "mailbox",
-            "max_storage": 1000,
             "can_admin_maildomains": [],
-            "can_store_entitlement_account_override": None,
-            "can_store_entitlement_account": {"max_storage": 1000},
-            "can_store_entitlement_organization": None,
-            "can_store_metric_account": {
-                "key": "storage_used",
-                "value": 500,
-            },
-            "can_store_metric_organization": None,
+            "max_storage_account": 1000,
         },
         "metrics": {
-            "storage_used": 500,
+            "account": {"storage_used": 500},
+            "organization": None,
         },
     }
 
@@ -248,19 +241,12 @@ def test_api_entitlements_mailbox_can_store(
             "can_access": True,
             "can_store": False,
             "can_store_resolve_level": "mailbox",
-            "max_storage": 1000,
             "can_admin_maildomains": [],
-            "can_store_entitlement_account_override": None,
-            "can_store_entitlement_account": {"max_storage": 1000},
-            "can_store_entitlement_organization": None,
-            "can_store_metric_account": {
-                "key": "storage_used",
-                "value": 1001,
-            },
-            "can_store_metric_organization": None,
+            "max_storage_account": 1000,
         },
         "metrics": {
-            "storage_used": 1001,
+            "account": {"storage_used": 1001},
+            "organization": None,
         },
     }
 
@@ -427,12 +413,6 @@ def test_api_entitlements_organization_can_store(
     )
     assert response.status_code == 200
     data = response.json()
-    expected_max_storage = 10000 if resolve_level == "organization" else 1000
-    expected_storage_used = (
-        organization_storage_used
-        if resolve_level == "organization"
-        else mailbox_storage_used
-    )
     assert data == {
         "organization": {
             "id": str(organization.id),
@@ -451,22 +431,13 @@ def test_api_entitlements_organization_can_store(
             "can_access": True,
             "can_store": can_store,
             "can_store_resolve_level": resolve_level,
-            "max_storage": expected_max_storage,
             "can_admin_maildomains": [],
-            "can_store_entitlement_account_override": None,
-            "can_store_entitlement_account": {"max_storage": 1000},
-            "can_store_entitlement_organization": {"max_storage": 10000},
-            "can_store_metric_account": {
-                "key": "storage_used",
-                "value": mailbox_storage_used,
-            },
-            "can_store_metric_organization": {
-                "key": "storage_used",
-                "value": organization_storage_used,
-            },
+            "max_storage_account": 1000,
+            "max_storage_organization": 10000,
         },
         "metrics": {
-            "storage_used": expected_storage_used,
+            "account": {"storage_used": mailbox_storage_used},
+            "organization": {"storage_used": organization_storage_used},
         },
     }
 
@@ -674,22 +645,13 @@ def test_api_entitlements_mailbox_override_can_store(
             "can_access": True,
             "can_store": can_store_before_override,
             "can_store_resolve_level": "mailbox",
-            "max_storage": 500,
             "can_admin_maildomains": [],
-            "can_store_entitlement_account_override": None,
-            "can_store_entitlement_account": {"max_storage": 500},
-            "can_store_entitlement_organization": {"max_storage": 1000},
-            "can_store_metric_account": {
-                "key": "storage_used",
-                "value": mailbox_storage_used,
-            },
-            "can_store_metric_organization": {
-                "key": "storage_used",
-                "value": 800,
-            },
+            "max_storage_account": 500,
+            "max_storage_organization": 1000,
         },
         "metrics": {
-            "storage_used": mailbox_storage_used,
+            "account": {"storage_used": mailbox_storage_used},
+            "organization": {"storage_used": 800},
         },
     }
 
@@ -738,24 +700,14 @@ def test_api_entitlements_mailbox_override_can_store(
             "can_access": True,
             "can_store": can_store,
             "can_store_resolve_level": "mailbox_override",
-            "max_storage": override_max_storage,
             "can_admin_maildomains": [],
-            "can_store_entitlement_account_override": {
-                "max_storage": override_max_storage,
-            },
-            "can_store_entitlement_account": {"max_storage": 500},
-            "can_store_entitlement_organization": {"max_storage": 1000},
-            "can_store_metric_account": {
-                "key": "storage_used",
-                "value": mailbox_storage_used,
-            },
-            "can_store_metric_organization": {
-                "key": "storage_used",
-                "value": 800,
-            },
+            "max_storage_account_override": override_max_storage,
+            "max_storage_account": 500,
+            "max_storage_organization": 1000,
         },
         "metrics": {
-            "storage_used": mailbox_storage_used,
+            "account": {"storage_used": mailbox_storage_used},
+            "organization": {"storage_used": 800},
         },
     }
 
@@ -857,22 +809,13 @@ def test_api_entitlements_mailbox_override_can_store(
             "can_access": True,
             "can_store": can_store_before_override,
             "can_store_resolve_level": "mailbox",
-            "max_storage": 500,
             "can_admin_maildomains": [],
-            "can_store_entitlement_account_override": None,
-            "can_store_entitlement_account": {"max_storage": 500},
-            "can_store_entitlement_organization": {"max_storage": 1000},
-            "can_store_metric_account": {
-                "key": "storage_used",
-                "value": mailbox_storage_used,
-            },
-            "can_store_metric_organization": {
-                "key": "storage_used",
-                "value": 800,
-            },
+            "max_storage_account": 500,
+            "max_storage_organization": 1000,
         },
         "metrics": {
-            "storage_used": mailbox_storage_used,
+            "account": {"storage_used": mailbox_storage_used},
+            "organization": {"storage_used": 800},
         },
     }
     metrics_mailbox = models.Metric.objects.filter(
@@ -999,18 +942,11 @@ def test_api_entitlements_list_unlimited_storage(
             "can_access": True,
             "can_store": True,
             "can_store_resolve_level": "mailbox",
-            "max_storage": 0,
             "can_admin_maildomains": [],
-            "can_store_entitlement_account_override": None,
-            "can_store_entitlement_account": {"max_storage": 0},
-            "can_store_entitlement_organization": None,
-            "can_store_metric_account": {
-                "key": "storage_used",
-                "value": storage_used,
-            },
-            "can_store_metric_organization": None,
+            "max_storage_account": 0,
         },
         "metrics": {
-            "storage_used": storage_used,
+            "account": {"storage_used": storage_used},
+            "organization": None,
         },
     }

--- a/src/backend/core/tests/api/test_entitlements_transfers.py
+++ b/src/backend/core/tests/api/test_entitlements_transfers.py
@@ -81,6 +81,7 @@ def test_api_entitlements_transfers_can_access_with_active_drive_subscription():
         "entitlements": {
             "can_access": True,
         },
+        "metrics": {},
     }
 
 
@@ -156,6 +157,7 @@ def test_api_entitlements_transfers_can_access_without_drive_subscription():
             "can_access": False,
             "can_access_reason": TransfersAccessEntitlementResolver.Reason.NOT_ACTIVATED,
         },
+        "metrics": {},
     }
 
 
@@ -214,6 +216,7 @@ def test_api_entitlements_transfers_can_access_no_organization():
             "can_access": False,
             "can_access_reason": TransfersAccessEntitlementResolver.Reason.NO_ORGANIZATION,
         },
+        "metrics": {},
     }
 
 


### PR DESCRIPTION
## Purpose

The entitlement resolver now exposes, alongside the final decision, the per-level
entitlement and metric attributes (account override, account, organization) so
consumers can see *why* an entitlement resolved as it did and also implement a
usage gauge on apps.

## Changes

- Base resolver surfaces per-level entitlement and metric attributes.
- Drive storage resolver exposes `max_storage` at each resolution level.
- Messages storage resolver mirrors drive for consistency across services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entitlements API responses now provide a clearer, resolver-driven `metrics` breakdown, including account vs. organization storage limits and usage, plus override details where applicable.
  * Storage-related endpoints now return consistent `metrics` structure, including `metrics: {}` when no metrics apply.

* **Bug Fixes**
  * Improved consistency of storage permission evaluation across account, organization, and override scenarios.

* **Tests**
  * Updated entitlement API test expectations to match the new response shape (including `metrics` field changes across drive, messages, calendars, meet, and transfers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->