### PR TITLE
✨(entitlements) expose metrics attributes and accept pushed usage metrics

### DIFF
--- a/src/backend/core/api/viewsets/entitlements.py
+++ b/src/backend/core/api/viewsets/entitlements.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db.models import BooleanField, Case, Exists, OuterRef, Q, Value, When
 
 import rest_framework as drf
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -25,7 +26,7 @@ from core.entitlements.resolvers.entitlement_resolver import (
 from core.entitlements.resolvers.piggyback_access_entitlement_resolver import (
     PiggybackAccessEntitlementResolver,
 )
-from core.tasks.metrics import scrape_service_usage_metrics
+from core.tasks.metrics import scrape_service_usage_metrics, store_service_metrics
 
 
 class EntitlementOperatorSerializer(OperatorSerializer):
@@ -68,6 +69,89 @@ class EntitlementViewSerializer(serializers.Serializer):
             )
 
         return attrs
+
+
+# pylint: disable=abstract-method
+class EntitlementUsageMetricsPushSerializer(serializers.Serializer):
+    """
+    Optional POST body: usage metric items in the same format as the
+    service's usage_metrics_endpoint results, passed through unchanged
+    to store_service_metrics.
+    """
+
+    usage_metrics = serializers.ListField(child=serializers.DictField(), required=False)
+
+    def validate_usage_metrics(self, value):
+        """
+        Only validate the shapes the view relies on; anything else stays as
+        tolerant as the scrape path (bad rows are logged and skipped).
+        """
+        for index, item in enumerate(value):
+            if item.get("account") is not None and not isinstance(
+                item["account"], dict
+            ):
+                raise serializers.ValidationError(
+                    f"Item {index}: 'account' must be an object."
+                )
+            if item.get("metrics") is not None and not isinstance(
+                item["metrics"], dict
+            ):
+                raise serializers.ValidationError(
+                    f"Item {index}: 'metrics' must be an object."
+                )
+        return value
+
+
+def _refresh_usage_metrics(entitlement_context, entitlements_by_type, usage_metrics):
+    """
+    Store caller-pushed usage metrics and scrape the scopes they don't cover.
+    The caller is the service itself, so pushed items are as trusted as its
+    usage_metrics_endpoint.
+    """
+    service = entitlement_context["service"]
+    account_type = entitlement_context["account_type"]
+
+    # Always scrape incoming account metrics. (user, mailbox, etc.)
+    scrape_account = True
+    # Not all services supports organization account type.
+    scrape_organization = False
+
+    # Determine if we need to scrape organization metrics.
+    # We scrape organization metrics only if we have at least one organization entitlement.
+    for entitlements_of_type in entitlements_by_type.values():
+        entitlements_by_priority = get_entitlements_by_priority(entitlements_of_type)
+        if entitlements_by_priority.get("organization"):
+            scrape_organization = True
+
+    # Store the pushed metrics and skip the scrape for each account type
+    # they cover.
+    pushed_account_types = set()
+    if usage_metrics:
+        for item in usage_metrics:
+            item_account_type = (item.get("account") or {}).get("type")
+            if item_account_type:
+                pushed_account_types.add(item_account_type)
+        store_service_metrics(service, usage_metrics)
+
+    # Scrape metrics.
+    if scrape_account and account_type not in pushed_account_types:
+        scrape_filters = {
+            "account_type": account_type,
+        }
+        if entitlement_context["account_id"]:
+            scrape_filters["account_id_value"] = entitlement_context["account_id"]
+        if entitlement_context["account_email"]:
+            scrape_filters["account_email"] = entitlement_context["account_email"]
+        scrape_service_usage_metrics(service, scrape_filters)
+    if scrape_organization and "organization" not in pushed_account_types:
+        scrape_service_usage_metrics(
+            service,
+            {
+                "account_type": "organization",
+                "account_id_key": "siret",
+                "account_id_value": entitlement_context["siret"],
+            },
+        )
 
 
 def _get_piggyback_operator_data(access_resolver, entitlement_context):
@@ -150,6 +234,35 @@ class EntitlementView(APIView):
         """
         Get entitlements.
         """
+        return self._resolve_entitlements(request)
+
+    @extend_schema(
+        request=EntitlementUsageMetricsPushSerializer,
+        responses={200: OpenApiResponse(description="Same response as GET.")},
+    )
+    def post(self, request):
+        """
+        Get entitlements, exactly like GET (same query params, same response).
+
+        Additionally accepts an optional JSON body:
+        {"usage_metrics": [<items in the usage_metrics_endpoint format>]}
+        Pushed items are stored as if they had been scraped, and suppress the
+        HTTP scrape back to the service for each account type they cover
+        (the query param account_type and/or "organization"). Scopes not
+        covered by the body are still scraped as usual.
+        """
+        body_serializer = EntitlementUsageMetricsPushSerializer(data=request.data)
+        body_serializer.is_valid(raise_exception=True)
+        # An empty list behaves exactly like an absent key (full scraping).
+        usage_metrics = body_serializer.validated_data.get("usage_metrics") or None
+        return self._resolve_entitlements(request, usage_metrics=usage_metrics)
+
+    def _resolve_entitlements(self, request, usage_metrics=None):
+        """
+        Resolve entitlements for the given request query params. When
+        usage_metrics items are provided, they replace the corresponding
+        usage-metrics scrapes.
+        """
 
         serializer = EntitlementViewSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
@@ -219,39 +332,9 @@ class EntitlementView(APIView):
                     entitlements_by_type[entitlement.type] = []
                 entitlements_by_type[entitlement.type].append(entitlement)
 
-            # Always scrape incoming account metrics. (user, mailbox, etc.)
-            scrape_account = True
-            # Not all services supports organization account type.
-            scrape_organization = False
-
-            # Determine if we need to scrape organization metrics.
-            # We scrape organization metrics only if we have at least one organization entitlement.
-            for _entitlement_type, entitlements_of_type in entitlements_by_type.items():
-                entitlements_by_priority = get_entitlements_by_priority(
-                    entitlements_of_type
-                )
-                if entitlements_by_priority.get("organization"):
-                    scrape_organization = True
-
-            # Scrape metrics.
-            if scrape_account:
-                scrape_filters = {
-                    "account_type": account_type,
-                }
-                if account_id:
-                    scrape_filters["account_id_value"] = account_id
-                if account_email:
-                    scrape_filters["account_email"] = account_email
-                scrape_service_usage_metrics(service, scrape_filters)
-            if scrape_organization:
-                scrape_service_usage_metrics(
-                    service,
-                    {
-                        "account_type": "organization",
-                        "account_id_key": "siret",
-                        "account_id_value": siret,
-                    },
-                )
+            _refresh_usage_metrics(
+                entitlement_context, entitlements_by_type, usage_metrics
+            )
 
             # Resolve entitlements.
             for entitlement_type, entitlements_of_type in entitlements_by_type.items():

--- a/src/backend/core/tests/api/test_entitlements_push_metrics.py
+++ b/src/backend/core/tests/api/test_entitlements_push_metrics.py
@@ -1,0 +1,412 @@
+# pylint: disable=invalid-name
+"""
+Test pushing usage metrics in the body of POST /entitlements.
+
+Callers can provide the usage metrics the endpoint would otherwise scrape
+over HTTP. Each pushed account type suppresses the corresponding scrape.
+"""
+
+import pytest
+import responses
+from responses import matchers
+from rest_framework.test import APIClient
+
+from core import factories, models
+from core.tests.utils import assert_equals_partial
+
+pytestmark = pytest.mark.django_db
+
+# pylint: disable=assignment-from-none
+# pylint: disable=duplicate-code
+
+METRICS_USAGE_ENDPOINT = "https://fichiers.suite.anct.gouv.fr/metrics/usage"
+SIRET = "12345678900001"
+
+PUSHED_USER_ITEM = {
+    "siret": SIRET,
+    "account": {"type": "user", "id": "xyz", "email": "test@example.com"},
+    "metrics": {"storage_used": 700},
+}
+PUSHED_ORGANIZATION_ITEM = {
+    "siret": SIRET,
+    "account": {"type": "organization"},
+    "metrics": {"storage_used": 1500},
+}
+
+
+def _setup_drive_subscription(is_active=True):
+    """Create an organization with a drive subscription and its default entitlements."""
+    organization = factories.OrganizationFactory(siret=SIRET)
+    operator = factories.OperatorFactory()
+    factories.OperatorOrganizationRoleFactory(
+        operator=operator, organization=organization
+    )
+    service = factories.ServiceFactory(
+        type="drive",
+        config={
+            "entitlements_api_key": "test_token",
+            "usage_metrics_endpoint": METRICS_USAGE_ENDPOINT,
+            "metrics_auth_token": "test_token",
+        },
+    )
+    factories.ServiceSubscriptionFactory(
+        organization=organization,
+        service=service,
+        operator=operator,
+        is_active=is_active,
+    )
+    return organization, operator, service
+
+
+def _register_scrape_mocks():
+    """Register the account and organization usage metrics scrape mocks.
+
+    Scrape errors are swallowed by scrape_service_usage_metrics, so whether
+    the view scraped must be asserted via each mock's call_count.
+    """
+    user_mock = responses.add(
+        responses.GET,
+        METRICS_USAGE_ENDPOINT,
+        match=[
+            matchers.query_param_matcher(
+                {
+                    "account_type": "user",
+                    "account_id_value": "xyz",
+                    "limit": 1000,
+                    "offset": 0,
+                }
+            )
+        ],
+        json={
+            "count": 1,
+            "results": [
+                {
+                    "siret": SIRET,
+                    "account": {
+                        "type": "user",
+                        "id": "xyz",
+                        "email": "test@example.com",
+                    },
+                    "metrics": {"storage_used": 500},
+                }
+            ],
+        },
+        status=200,
+    )
+    organization_mock = responses.add(
+        responses.GET,
+        METRICS_USAGE_ENDPOINT,
+        match=[
+            matchers.query_param_matcher(
+                {
+                    "account_type": "organization",
+                    "account_id_key": "siret",
+                    "account_id_value": SIRET,
+                    "limit": 1000,
+                    "offset": 0,
+                }
+            )
+        ],
+        json={
+            "count": 1,
+            "results": [
+                {
+                    "siret": SIRET,
+                    "account": {"type": "organization"},
+                    "metrics": {"storage_used": 1000},
+                }
+            ],
+        },
+        status=200,
+    )
+    return user_mock, organization_mock
+
+
+def _post_entitlements(service, siret, body=None, token="test_token"):
+    """POST /entitlements with the same query params as the GET flavor."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+    return client.post(
+        "/api/v1.0/entitlements/",
+        data=body,
+        format="json",
+        query_params={
+            "service_id": service.id,
+            "account_type": "user",
+            "account_id": "xyz",
+            "siret": siret,
+        },
+        headers={"X-Service-Auth": f"Bearer {token}"},
+    )
+
+
+def _get_stored_value(service, organization, account_type, external_id):
+    """Return the stored metric value for the given account, or None."""
+    metric = models.Metric.objects.filter(
+        service=service,
+        organization=organization,
+        account__type=account_type,
+        account__external_id=external_id,
+    ).first()
+    return metric.value if metric else None
+
+
+@responses.activate
+@pytest.mark.parametrize("body", [None, {}, {"usage_metrics": []}])
+def test_api_entitlements_post_without_metrics_matches_get(body):
+    """POST without pushed metrics must behave exactly like GET: both scrapes run."""
+    organization, operator, service = _setup_drive_subscription()
+    user_mock, organization_mock = _register_scrape_mocks()
+
+    response = _post_entitlements(service, organization.siret, body=body)
+
+    assert response.status_code == 200
+    assert user_mock.call_count == 1
+    assert organization_mock.call_count == 1
+    assert_equals_partial(
+        response.json(),
+        {
+            "operator": {
+                "id": str(operator.id),
+                "name": operator.name,
+            },
+            "entitlements": {
+                "can_access": True,
+                "can_upload": True,
+                "can_upload_resolve_level": "user",
+                "max_storage_account": 1000 * 1000 * 1000 * 5,
+                "max_storage_organization": 1000 * 1000 * 1000 * 10,
+            },
+            "metrics": {
+                "account": {"storage_used": 500},
+                "organization": {"storage_used": 1000},
+            },
+        },
+    )
+    assert _get_stored_value(service, organization, "user", "xyz") == 500
+    assert (
+        _get_stored_value(service, organization, "organization", organization.siret)
+        == 1000
+    )
+
+
+@responses.activate
+def test_api_entitlements_post_with_all_metrics_skips_all_scrapes():
+    """Pushing both user and organization metrics must avoid any HTTP scrape."""
+    organization, _operator, service = _setup_drive_subscription()
+    user_mock, organization_mock = _register_scrape_mocks()
+
+    response = _post_entitlements(
+        service,
+        organization.siret,
+        body={"usage_metrics": [PUSHED_USER_ITEM, PUSHED_ORGANIZATION_ITEM]},
+    )
+
+    assert response.status_code == 200
+    assert user_mock.call_count == 0
+    assert organization_mock.call_count == 0
+    assert_equals_partial(
+        response.json(),
+        {
+            "entitlements": {
+                "can_access": True,
+                "can_upload": True,
+                "can_upload_resolve_level": "user",
+            },
+            "metrics": {
+                "account": {"storage_used": 700},
+                "organization": {"storage_used": 1500},
+            },
+        },
+    )
+
+    # Pushed metrics are stored exactly like scraped ones.
+    metric_user = models.Metric.objects.get(
+        service=service,
+        organization=organization,
+        account__type="user",
+        account__external_id="xyz",
+    )
+    assert metric_user.key == "storage_used"
+    assert metric_user.value == 700
+    assert metric_user.account.email == "test@example.com"
+
+    # The organization account is created with the siret as external_id,
+    # like the scrape path does when the item has no account id.
+    metric_organization = models.Metric.objects.get(
+        service=service,
+        organization=organization,
+        account__type="organization",
+        account__external_id=organization.siret,
+    )
+    assert metric_organization.key == "storage_used"
+    assert metric_organization.value == 1500
+
+
+@responses.activate
+def test_api_entitlements_post_pushed_metrics_drive_resolution():
+    """Entitlements must be resolved from the pushed values (organization full here)."""
+    organization, _operator, service = _setup_drive_subscription()
+    user_mock, organization_mock = _register_scrape_mocks()
+
+    over_quota_organization_item = {
+        **PUSHED_ORGANIZATION_ITEM,
+        "metrics": {"storage_used": 1000 * 1000 * 1000 * 11},
+    }
+    response = _post_entitlements(
+        service,
+        organization.siret,
+        body={"usage_metrics": [PUSHED_USER_ITEM, over_quota_organization_item]},
+    )
+
+    assert response.status_code == 200
+    assert user_mock.call_count == 0
+    assert organization_mock.call_count == 0
+    assert_equals_partial(
+        response.json(),
+        {
+            "entitlements": {
+                "can_upload": False,
+                "can_upload_resolve_level": "organization",
+            },
+        },
+    )
+
+
+@responses.activate
+def test_api_entitlements_post_with_user_metrics_still_scrapes_organization():
+    """Pushing only user metrics must leave the organization scrape untouched."""
+    organization, _operator, service = _setup_drive_subscription()
+    user_mock, organization_mock = _register_scrape_mocks()
+
+    response = _post_entitlements(
+        service,
+        organization.siret,
+        body={"usage_metrics": [PUSHED_USER_ITEM]},
+    )
+
+    assert response.status_code == 200
+    assert user_mock.call_count == 0
+    assert organization_mock.call_count == 1
+    assert_equals_partial(
+        response.json(),
+        {
+            "metrics": {
+                "account": {"storage_used": 700},
+                "organization": {"storage_used": 1000},
+            },
+        },
+    )
+
+
+@responses.activate
+def test_api_entitlements_post_with_organization_metrics_still_scrapes_account():
+    """Pushing only organization metrics must leave the account scrape untouched."""
+    organization, _operator, service = _setup_drive_subscription()
+    user_mock, organization_mock = _register_scrape_mocks()
+
+    response = _post_entitlements(
+        service,
+        organization.siret,
+        body={"usage_metrics": [PUSHED_ORGANIZATION_ITEM]},
+    )
+
+    assert response.status_code == 200
+    assert user_mock.call_count == 1
+    assert organization_mock.call_count == 0
+    assert_equals_partial(
+        response.json(),
+        {
+            "metrics": {
+                "account": {"storage_used": 500},
+                "organization": {"storage_used": 1500},
+            },
+        },
+    )
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"usage_metrics": "nope"},
+        {"usage_metrics": [123]},
+        {"usage_metrics": [{"siret": SIRET, "account": "user", "metrics": {}}]},
+        {"usage_metrics": [{"siret": SIRET, "metrics": "x"}]},
+    ],
+)
+def test_api_entitlements_post_malformed_body(body):
+    """Malformed bodies must be rejected with a 400 before anything is stored."""
+    organization, _operator, service = _setup_drive_subscription()
+
+    response = _post_entitlements(service, organization.siret, body=body)
+
+    assert response.status_code == 400
+    assert not models.Metric.objects.exists()
+
+
+@responses.activate
+def test_api_entitlements_post_inactive_subscription_stores_nothing():
+    """Without an active subscription, pushed metrics are ignored, like scrapes."""
+    organization, _operator, service = _setup_drive_subscription(is_active=False)
+
+    response = _post_entitlements(
+        service,
+        organization.siret,
+        body={"usage_metrics": [PUSHED_USER_ITEM, PUSHED_ORGANIZATION_ITEM]},
+    )
+
+    assert response.status_code == 200
+    assert not models.Metric.objects.exists()
+
+
+@responses.activate
+def test_api_entitlements_post_unknown_siret_item_is_skipped():
+    """An item for an unknown organization is skipped but still covers its scope."""
+    organization, _operator, service = _setup_drive_subscription()
+    user_mock, organization_mock = _register_scrape_mocks()
+
+    unknown_siret_item = {**PUSHED_USER_ITEM, "siret": "99999999999999"}
+    response = _post_entitlements(
+        service,
+        organization.siret,
+        body={"usage_metrics": [unknown_siret_item]},
+    )
+
+    assert response.status_code == 200
+    # The caller asserted it pushed the user scope, so no account scrape.
+    assert user_mock.call_count == 0
+    assert organization_mock.call_count == 1
+    # The unresolvable item was skipped, nothing stored for the user.
+    assert _get_stored_value(service, organization, "user", "xyz") is None
+
+
+@responses.activate
+def test_api_entitlements_post_authentication():
+    """POST must enforce the same service authentication as GET."""
+    organization, _operator, service = _setup_drive_subscription()
+
+    response = _post_entitlements(
+        service,
+        organization.siret,
+        body={"usage_metrics": [PUSHED_USER_ITEM]},
+        token="wrong_token",
+    )
+    assert response.status_code == 403
+    assert not models.Metric.objects.exists()
+
+    client = APIClient()
+    response = client.post(
+        "/api/v1.0/entitlements/",
+        data={"usage_metrics": [PUSHED_USER_ITEM]},
+        format="json",
+        query_params={
+            "service_id": service.id,
+            "account_type": "user",
+            "account_id": "xyz",
+            "siret": organization.siret,
+        },
+    )
+    assert response.status_code == 401
+    assert not models.Metric.objects.exists()


### PR DESCRIPTION

  * Added support for submitting usage metrics when resolving entitlements.
  * Missing metric scopes are automatically retrieved as needed.
